### PR TITLE
feat: `output` option

### DIFF
--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -41,7 +41,6 @@ npx @icp-sdk/bindgen --did-file ./canisters/hello_world.did --out-dir ./src/bind
 - `--did-file <path>`: Path to the `.did` file to generate bindings from
 - `--out-dir <dir>`: Directory where the bindings will be written
 - `--interface-declaration`: If set, generates a `<service-name>.d.ts` file that contains the same types of the `<service-name>.ts` file.
-- `--declarations-only`: If set, only generates the declarations folder, skipping the actor file (`index.ts`) and service wrapper file (`<service-name>.ts`)
+- `--disable-actor`: If set, only generates the declarations folder, skipping the actor file (`index.ts`) and service wrapper file (`<service-name>.ts`)
 
 > **Note**: The CLI does not support additional features yet.
-> **Note**: If your `.did` file is located inside the output directory, it will be temporarily copied during generation to avoid being deleted.

--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -41,5 +41,7 @@ npx @icp-sdk/bindgen --did-file ./canisters/hello_world.did --out-dir ./src/bind
 - `--did-file <path>`: Path to the `.did` file to generate bindings from
 - `--out-dir <dir>`: Directory where the bindings will be written
 - `--interface-declaration`: If set, generates a `<service-name>.d.ts` file that contains the same types of the `<service-name>.ts` file.
+- `--declarations-only`: If set, only generates the declarations folder, skipping the actor file (`index.ts`) and service wrapper file (`<service-name>.ts`)
 
 > **Note**: The CLI does not support additional features yet.
+> **Note**: If your `.did` file is located inside the output directory, it will be temporarily copied during generation to avoid being deleted.

--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -40,7 +40,7 @@ npx @icp-sdk/bindgen --did-file ./canisters/hello_world.did --out-dir ./src/bind
 
 - `--did-file <path>`: Path to the `.did` file to generate bindings from
 - `--out-dir <dir>`: Directory where the bindings will be written
-- `--interface-declaration`: If set, generates a `<service-name>.d.ts` file that contains the same types of the `<service-name>.ts` file.
-- `--disable-actor`: If set, only generates the declarations folder, skipping the actor file (`index.ts`) and service wrapper file (`<service-name>.ts`)
+- `--actor-interface-file`: If set, generates a `<service-name>.d.ts` file that contains the same types of the `<service-name>.ts` file. Has no effect if `--actor-disabled` is set.
+- `--actor-disabled`: If set, skips generating the actor file (`index.ts`) and service wrapper file (`<service-name>.ts`)
 
 > **Note**: The CLI does not support additional features yet.

--- a/docs/src/content/docs/plugins/vite.md
+++ b/docs/src/content/docs/plugins/vite.md
@@ -44,6 +44,23 @@ The path to the `.did` file to generate bindings from.
 
 The directory where the bindings will be written.
 
+#### `output`
+
+Options for controlling the generated output files.
+
+##### `declarationsOnly`
+
+If `true`, only generates the declarations folder and skips generating the actor file (`index.ts`) and service wrapper file (`<service-name>.ts`).
+
+> **Note**: If `true`, [`interfaceFile`](#interfaceFile) must be `false`.
+
+##### `interfaceFile`
+
+If `true`, generates a `<service-name>.d.ts` file that contains the same types of the `<service-name>.ts` file.
+Useful to add to LLMs' contexts' to give knowledge about what types are available in the service.
+
+> **Note**: If `true`, [`declarationsOnly`](#declarationsOnly) must be `false`.
+
 #### `additionalFeatures`
 
 Additional features to generate bindings with.

--- a/docs/src/content/docs/plugins/vite.md
+++ b/docs/src/content/docs/plugins/vite.md
@@ -48,18 +48,16 @@ The directory where the bindings will be written.
 
 Options for controlling the generated output files.
 
-##### `disableActor`
+##### `actor.disabled`
 
-If `true`, only generates the declarations folder and skips generating the actor file (`index.ts`) and service wrapper file (`<service-name>.ts`).
+If `true`, skips generating the actor file (`index.ts`) and service wrapper file (`<service-name>.ts`).
 
-> **Note**: If `true`, [`interfaceFile`](#interfaceFile) must be `false`.
-
-##### `interfaceFile`
+##### `actor.interfaceFile`
 
 If `true`, generates a `<service-name>.d.ts` file that contains the same types of the `<service-name>.ts` file.
 Useful to add to LLMs' contexts' to give knowledge about what types are available in the service.
 
-> **Note**: If `true`, [`disableActor`](#disableActor) must be `false`.
+> **Note**: Has no effect if `actor.disabled` is `true`.
 
 #### `additionalFeatures`
 

--- a/docs/src/content/docs/plugins/vite.md
+++ b/docs/src/content/docs/plugins/vite.md
@@ -48,7 +48,7 @@ The directory where the bindings will be written.
 
 Options for controlling the generated output files.
 
-##### `declarationsOnly`
+##### `disableActor`
 
 If `true`, only generates the declarations folder and skips generating the actor file (`index.ts`) and service wrapper file (`<service-name>.ts`).
 
@@ -59,7 +59,7 @@ If `true`, only generates the declarations folder and skips generating the actor
 If `true`, generates a `<service-name>.d.ts` file that contains the same types of the `<service-name>.ts` file.
 Useful to add to LLMs' contexts' to give knowledge about what types are available in the service.
 
-> **Note**: If `true`, [`declarationsOnly`](#declarationsOnly) must be `false`.
+> **Note**: If `true`, [`disableActor`](#disableActor) must be `false`.
 
 #### `additionalFeatures`
 

--- a/docs/src/content/docs/structure.md
+++ b/docs/src/content/docs/structure.md
@@ -22,11 +22,11 @@ This file contains the actual Candid JS bindings, that allow encoding and decodi
 
 ## `<service-name>.ts`
 
-This file contains the TypeScript wrapper for the Candid JS bindings generated in [`declarations/<service-name>.did.js`](#declarationsservice-namedidjs). It offers a more idiomatic and type-safe TypeScript interface over the Candid JS bindings.
+This file contains the TypeScript wrapper for the Candid JS bindings generated in [`declarations/<service-name>.did.js`](#declarationsservice-namedidjs). It offers a more idiomatic and type-safe TypeScript interface over the Candid JS bindings. Set the [`output.declarationsOnly`](./core/api/type-aliases/GenerateOutputOptions.md#declarationsOnly) option to `true` to skip generating this file.
 
 ## `index.ts`
 
-This file contains the `createActor` function that can be used to instantiate the Candid JS bindings generated in [`declarations/<service-name>.did.js`](#declarationsservice-namedidjs).
+This file contains the `createActor` function that can be used to instantiate the Candid JS bindings generated in [`declarations/<service-name>.did.js`](#declarationsservice-namedidjs). Set the [`output.declarationsOnly`](./core/api/type-aliases/GenerateOutputOptions.md#declarationsOnly) option to `true` to skip generating this file.
 
 Here's an example of how to use the generated client:
 
@@ -41,7 +41,7 @@ const greeting = await actor.greet('World');
 
 ### `<service-name>.d.ts`
 
-This file contains the same TypeScript types as [`<service-name>.ts`](#service-namets). It is typically used to add to LLMs' contexts' to give knowledge about what types are available in the service. Set the [`interfaceDeclaration`](./core/api/type-aliases/GenerateOptions.md#interfaceDeclaration) option to `true` to generate this file.
+This file contains the same TypeScript types as [`<service-name>.ts`](#service-namets). It is typically used to add to LLMs' contexts' to give knowledge about what types are available in the service. Set the [`output.interfaceFile`](./core/api/type-aliases/GenerateOutputOptions.md#interfaceFile) option to `true` to generate this file.
 
 ### `canister-env.d.ts`
 

--- a/docs/src/content/docs/structure.md
+++ b/docs/src/content/docs/structure.md
@@ -22,11 +22,11 @@ This file contains the actual Candid JS bindings, that allow encoding and decodi
 
 ## `<service-name>.ts`
 
-This file contains the TypeScript wrapper for the Candid JS bindings generated in [`declarations/<service-name>.did.js`](#declarationsservice-namedidjs). It offers a more idiomatic and type-safe TypeScript interface over the Candid JS bindings. Set the [`output.declarationsOnly`](./core/api/type-aliases/GenerateOutputOptions.md#declarationsOnly) option to `true` to skip generating this file.
+This file contains the TypeScript wrapper for the Candid JS bindings generated in [`declarations/<service-name>.did.js`](#declarationsservice-namedidjs). It offers a more idiomatic and type-safe TypeScript interface over the Candid JS bindings. Set the [`output.disableActor`](./core/api/type-aliases/GenerateOutputOptions.md#disableActor) option to `true` to skip generating this file.
 
 ## `index.ts`
 
-This file contains the `createActor` function that can be used to instantiate the Candid JS bindings generated in [`declarations/<service-name>.did.js`](#declarationsservice-namedidjs). Set the [`output.declarationsOnly`](./core/api/type-aliases/GenerateOutputOptions.md#declarationsOnly) option to `true` to skip generating this file.
+This file contains the `createActor` function that can be used to instantiate the Candid JS bindings generated in [`declarations/<service-name>.did.js`](#declarationsservice-namedidjs). Set the [`output.disableActor`](./core/api/type-aliases/GenerateOutputOptions.md#disableActor) option to `true` to skip generating this file.
 
 Here's an example of how to use the generated client:
 

--- a/docs/src/content/docs/structure.md
+++ b/docs/src/content/docs/structure.md
@@ -22,11 +22,11 @@ This file contains the actual Candid JS bindings, that allow encoding and decodi
 
 ## `<service-name>.ts`
 
-This file contains the TypeScript wrapper for the Candid JS bindings generated in [`declarations/<service-name>.did.js`](#declarationsservice-namedidjs). It offers a more idiomatic and type-safe TypeScript interface over the Candid JS bindings. Set the [`output.disableActor`](./core/api/type-aliases/GenerateOutputOptions.md#disableActor) option to `true` to skip generating this file.
+This file contains the TypeScript wrapper for the Candid JS bindings generated in [`declarations/<service-name>.did.js`](#declarationsservice-namedidjs). It offers a more idiomatic and type-safe TypeScript interface over the Candid JS bindings. Set the [`output.actor.disabled`](./core/api/type-aliases/GenerateOutputOptions.md#disabled) option to `true` to skip generating this file.
 
 ## `index.ts`
 
-This file contains the `createActor` function that can be used to instantiate the Candid JS bindings generated in [`declarations/<service-name>.did.js`](#declarationsservice-namedidjs). Set the [`output.disableActor`](./core/api/type-aliases/GenerateOutputOptions.md#disableActor) option to `true` to skip generating this file.
+This file contains the `createActor` function that can be used to instantiate the Candid JS bindings generated in [`declarations/<service-name>.did.js`](#declarationsservice-namedidjs). Set the [`output.actor.disabled`](./core/api/type-aliases/GenerateOutputOptions.md#disabled) option to `true` to skip generating this file.
 
 Here's an example of how to use the generated client:
 
@@ -41,7 +41,7 @@ const greeting = await actor.greet('World');
 
 ### `<service-name>.d.ts`
 
-This file contains the same TypeScript types as [`<service-name>.ts`](#service-namets). It is typically used to add to LLMs' contexts' to give knowledge about what types are available in the service. Set the [`output.interfaceFile`](./core/api/type-aliases/GenerateOutputOptions.md#interfaceFile) option to `true` to generate this file.
+This file contains the same TypeScript types as [`<service-name>.ts`](#service-namets). It is typically used to add to LLMs' contexts' to give knowledge about what types are available in the service. Set the [`output.actor.interfaceFile`](./core/api/type-aliases/GenerateOutputOptions.md#interfaceFile) option to `true` to generate this file.
 
 ### `canister-env.d.ts`
 

--- a/src/cli/icp-bindgen.ts
+++ b/src/cli/icp-bindgen.ts
@@ -14,20 +14,22 @@ const CLI_NAME = 'icp-bindgen';
 type Args = {
   didFile: string;
   outDir: string;
-  interfaceFile?: boolean;
-  disableActor?: boolean;
+  actorInterfaceFile?: boolean;
+  actorDisabled?: boolean;
 };
 
 async function run(args: Args) {
-  const { didFile, outDir, interfaceFile, disableActor } = args;
+  const { didFile, outDir, actorInterfaceFile, actorDisabled } = args;
 
   console.log(cyan(`[${CLI_NAME}] Generating bindings...`));
   await generate({
     didFile,
     outDir,
     output: {
-      interfaceFile,
-      disableActor,
+      actor: {
+        disabled: actorDisabled,
+        interfaceFile: actorInterfaceFile,
+      },
     },
   });
   console.log(cyan(`[${CLI_NAME}] Generated bindings successfully at`), green(outDir));
@@ -44,13 +46,13 @@ program
   .requiredOption('--did-file <path>', 'Path to the .did file to generate bindings from')
   .requiredOption('--out-dir <dir>', 'Directory where the bindings will be written')
   .option(
-    '--interface-file',
-    'If set, generates a `<service-name>.d.ts` file that contains the same types of the `<service-name>.ts` file. Cannot be used with `--disable-actor`.',
+    '--actor-disabled',
+    'If set, only generates the declarations folder, skipping the actor file (index.ts) and service wrapper file (<service-name>.ts).',
     false,
   )
   .option(
-    '--disable-actor',
-    'If set, only generates the declarations folder, skipping the actor file (index.ts) and service wrapper file (<service-name>.ts). Cannot be used with `--interface-file`.',
+    '--actor-interface-file',
+    'If set, generates a `<service-name>.d.ts` file that contains the same types of the `<service-name>.ts` file. Has no effect if `--actor-disabled` is set.',
     false,
   )
   .action(run);

--- a/src/cli/icp-bindgen.ts
+++ b/src/cli/icp-bindgen.ts
@@ -14,14 +14,22 @@ const CLI_NAME = 'icp-bindgen';
 type Args = {
   didFile: string;
   outDir: string;
-  interfaceDeclaration?: boolean;
+  interfaceFile?: boolean;
+  declarationsOnly?: boolean;
 };
 
 async function run(args: Args) {
-  const { didFile, outDir, interfaceDeclaration } = args;
+  const { didFile, outDir, interfaceFile, declarationsOnly } = args;
 
   console.log(cyan(`[${CLI_NAME}] Generating bindings...`));
-  await generate({ didFile, outDir, interfaceDeclaration });
+  await generate({
+    didFile,
+    outDir,
+    output: {
+      interfaceFile,
+      declarationsOnly,
+    },
+  });
   console.log(cyan(`[${CLI_NAME}] Generated bindings successfully at`), green(outDir));
 }
 
@@ -36,8 +44,14 @@ program
   .requiredOption('--did-file <path>', 'Path to the .did file to generate bindings from')
   .requiredOption('--out-dir <dir>', 'Directory where the bindings will be written')
   .option(
-    '--interface-declaration',
-    'If set, generates a `<service-name>.d.ts` file that contains the same types of the `<service-name>.ts` file.',
+    '--interface-file',
+    'If set, generates a `<service-name>.d.ts` file that contains the same types of the `<service-name>.ts` file. Cannot be used with `--declarations-only`.',
+    false,
+  )
+  .option(
+    '--declarations-only',
+    'If set, only generates the declarations folder, skipping the actor file (index.ts) and service wrapper file (<service-name>.ts). Cannot be used with `--interface-file`.',
+    false,
   )
   .action(run);
 

--- a/src/cli/icp-bindgen.ts
+++ b/src/cli/icp-bindgen.ts
@@ -15,11 +15,11 @@ type Args = {
   didFile: string;
   outDir: string;
   interfaceFile?: boolean;
-  declarationsOnly?: boolean;
+  disableActor?: boolean;
 };
 
 async function run(args: Args) {
-  const { didFile, outDir, interfaceFile, declarationsOnly } = args;
+  const { didFile, outDir, interfaceFile, disableActor } = args;
 
   console.log(cyan(`[${CLI_NAME}] Generating bindings...`));
   await generate({
@@ -27,7 +27,7 @@ async function run(args: Args) {
     outDir,
     output: {
       interfaceFile,
-      declarationsOnly,
+      disableActor,
     },
   });
   console.log(cyan(`[${CLI_NAME}] Generated bindings successfully at`), green(outDir));
@@ -45,11 +45,11 @@ program
   .requiredOption('--out-dir <dir>', 'Directory where the bindings will be written')
   .option(
     '--interface-file',
-    'If set, generates a `<service-name>.d.ts` file that contains the same types of the `<service-name>.ts` file. Cannot be used with `--declarations-only`.',
+    'If set, generates a `<service-name>.d.ts` file that contains the same types of the `<service-name>.ts` file. Cannot be used with `--disable-actor`.',
     false,
   )
   .option(
-    '--declarations-only',
+    '--disable-actor',
     'If set, only generates the declarations folder, skipping the actor file (index.ts) and service wrapper file (<service-name>.ts). Cannot be used with `--interface-file`.',
     false,
   )

--- a/src/core/generate/fs.ts
+++ b/src/core/generate/fs.ts
@@ -1,9 +1,22 @@
-import { mkdir, rm } from 'node:fs/promises';
+import { mkdir, readdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
 
 export async function ensureDir(dir: string) {
   await mkdir(dir, { recursive: true });
 }
 
-export async function emptyDir(dir: string) {
+export async function emptyDirWithFilter(dir: string, filter?: (path: string) => boolean) {
+  if (!filter) {
+    await emptyDir(dir);
+    return;
+  }
+
+  const files = await readdir(dir);
+  await Promise.all(
+    files.filter(filter).map((file) => rm(join(dir, file), { recursive: true, force: true })),
+  );
+}
+
+async function emptyDir(dir: string) {
   await rm(dir, { recursive: true, force: true });
 }

--- a/src/core/generate/index.ts
+++ b/src/core/generate/index.ts
@@ -24,12 +24,12 @@ export type GenerateOutputOptions = {
    *
    * @default false
    */
-  declarationsOnly?: boolean;
+  disableActor?: boolean;
   /**
    * If `true`, generates a `<service-name>.d.ts` file that contains the same types of the `<service-name>.ts` file.
    * Useful to add to LLMs' contexts' to give knowledge about what types are available in the service.
    *
-   * If `true`, {@link GenerateOutputOptions.declarationsOnly} must be `false`.
+   * If `true`, {@link GenerateOutputOptions.disableActor} must be `false`.
    *
    * @default false
    */
@@ -85,7 +85,7 @@ export async function generate(options: GenerateOptions) {
     didFile,
     outDir,
     output = {
-      declarationsOnly: false,
+      disableActor: false,
       interfaceFile: false,
     },
   } = options;
@@ -128,7 +128,7 @@ async function writeBindings({ bindings, outDir, outputFileName, output }: Write
   await writeFile(declarationsTsFile, declarationsTs);
   await writeFile(declarationsJsFile, declarationsJs);
 
-  if (output.declarationsOnly) {
+  if (output.disableActor) {
     return;
   }
 
@@ -152,7 +152,7 @@ async function writeIndex(outDir: string, outputFileName: string) {
 }
 
 function validateOptions(options: GenerateOptions) {
-  if (options.output?.declarationsOnly && options.output?.interfaceFile) {
-    throw new Error('Cannot generate an interface file when generating the declarations only');
+  if (options.output?.disableActor && options.output?.interfaceFile) {
+    throw new Error('Cannot generate an interface file when generating the actor is disabled');
   }
 }

--- a/src/core/generate/index.ts
+++ b/src/core/generate/index.ts
@@ -5,13 +5,40 @@ import {
   type GenerateAdditionalFeaturesOptions,
   generateAdditionalFeatures,
 } from './features/index.ts';
-import { emptyDir, ensureDir } from './fs.ts';
+import { emptyDirWithFilter, ensureDir } from './fs.ts';
 import { type WasmGenerateResult, wasmGenerate, wasmInit } from './rs.ts';
 
 export type { GenerateAdditionalFeaturesOptions } from './features/index.ts';
 
 const DID_FILE_EXTENSION = '.did';
 
+/**
+ * Options for controlling the generated output files.
+ */
+export type GenerateOutputOptions = {
+  /**
+   * If `true`, only generates the declarations folder.
+   * Skips generating the actor file (`index.ts`) and service wrapper file (`<service-name>.ts`).
+   *
+   * If `true`, {@link GenerateOutputOptions.interfaceFile} must be `false`.
+   *
+   * @default false
+   */
+  declarationsOnly?: boolean;
+  /**
+   * If `true`, generates a `<service-name>.d.ts` file that contains the same types of the `<service-name>.ts` file.
+   * Useful to add to LLMs' contexts' to give knowledge about what types are available in the service.
+   *
+   * If `true`, {@link GenerateOutputOptions.declarationsOnly} must be `false`.
+   *
+   * @default false
+   */
+  interfaceFile?: boolean;
+};
+
+/**
+ * Options for the {@link generate} function.
+ */
 export type GenerateOptions = {
   /**
    * The path to the `.did` file.
@@ -22,12 +49,9 @@ export type GenerateOptions = {
    */
   outDir: string;
   /**
-   * If `true`, generates a `<service-name>.d.ts` file that contains the same types of the `<service-name>.ts` file.
-   * Useful to add to LLMs' contexts' to give knowledge about what types are available in the service.
-   *
-   * @default false
+   * Options for controlling the generated output files.
    */
-  interfaceDeclaration?: boolean;
+  output?: GenerateOutputOptions;
   /**
    * Additional features to generate bindings with.
    */
@@ -55,12 +79,22 @@ export type GenerateOptions = {
 export async function generate(options: GenerateOptions) {
   await wasmInit();
 
-  const { didFile, outDir, interfaceDeclaration = false } = options;
+  validateOptions(options);
+
+  const {
+    didFile,
+    outDir,
+    output = {
+      declarationsOnly: false,
+      interfaceFile: false,
+    },
+  } = options;
+
   const didFilePath = resolve(didFile);
   const outputFileName = basename(didFile, DID_FILE_EXTENSION);
 
-  await emptyDir(outDir);
   await ensureDir(outDir);
+  await emptyDirWithFilter(outDir, (path) => !path.endsWith(DID_FILE_EXTENSION));
   await ensureDir(resolve(outDir, 'declarations'));
 
   const result = wasmGenerate(didFilePath, outputFileName);
@@ -69,42 +103,41 @@ export async function generate(options: GenerateOptions) {
     bindings: result,
     outDir,
     outputFileName,
-    interfaceDeclaration,
+    output,
   });
 
   if (options.additionalFeatures) {
     await generateAdditionalFeatures(options.additionalFeatures, options.outDir);
   }
-
-  await writeIndex(outDir, outputFileName);
 }
 
 type WriteBindingsOptions = {
   bindings: WasmGenerateResult;
   outDir: string;
   outputFileName: string;
-  interfaceDeclaration: boolean;
+  output: GenerateOutputOptions;
 };
 
-async function writeBindings({
-  bindings,
-  outDir,
-  outputFileName,
-  interfaceDeclaration,
-}: WriteBindingsOptions) {
+async function writeBindings({ bindings, outDir, outputFileName, output }: WriteBindingsOptions) {
   const declarationsTsFile = resolve(outDir, 'declarations', `${outputFileName}.did.d.ts`);
   const declarationsJsFile = resolve(outDir, 'declarations', `${outputFileName}.did.js`);
-  const serviceTsFile = resolve(outDir, `${outputFileName}.ts`);
 
   const declarationsTs = prepareBinding(bindings.declarations_ts);
   const declarationsJs = prepareBinding(bindings.declarations_js);
-  const serviceTs = prepareBinding(bindings.service_ts);
 
   await writeFile(declarationsTsFile, declarationsTs);
   await writeFile(declarationsJsFile, declarationsJs);
-  await writeFile(serviceTsFile, serviceTs);
 
-  if (interfaceDeclaration) {
+  if (output.declarationsOnly) {
+    return;
+  }
+
+  const serviceTsFile = resolve(outDir, `${outputFileName}.ts`);
+  const serviceTs = prepareBinding(bindings.service_ts);
+  await writeFile(serviceTsFile, serviceTs);
+  await writeIndex(outDir, outputFileName);
+
+  if (output.interfaceFile) {
     const interfaceTsFile = resolve(outDir, `${outputFileName}.d.ts`);
     const interfaceTs = prepareBinding(bindings.interface_ts);
     await writeFile(interfaceTsFile, interfaceTs);
@@ -116,4 +149,10 @@ async function writeIndex(outDir: string, outputFileName: string) {
 
   const index = indexBinding(outputFileName);
   await writeFile(indexFile, index);
+}
+
+function validateOptions(options: GenerateOptions) {
+  if (options.output?.declarationsOnly && options.output?.interfaceFile) {
+    throw new Error('Cannot generate an interface file when generating the declarations only');
+  }
 }

--- a/src/plugins/vite.ts
+++ b/src/plugins/vite.ts
@@ -53,6 +53,7 @@ export function icpBindgen(options: Options): Plugin {
       await generate({
         didFile: options.didFile,
         outDir: options.outDir,
+        output: options.output,
         additionalFeatures: options.additionalFeatures,
       });
 

--- a/tests/assets/snapshots/cli/help.snapshot
+++ b/tests/assets/snapshots/cli/help.snapshot
@@ -3,10 +3,13 @@ Usage: icp-bindgen [options]
 Generate JavaScript bindings for IC canisters
 
 Options:
-  -V, --version            output the version number
-  --did-file <path>        Path to the .did file to generate bindings from
-  --out-dir <dir>          Directory where the bindings will be written
-  --interface-declaration  If set, generates a `<service-name>.d.ts` file that
-                           contains the same types of the `<service-name>.ts`
-                           file.
-  -h, --help               display help for command
+  -V, --version        output the version number
+  --did-file <path>    Path to the .did file to generate bindings from
+  --out-dir <dir>      Directory where the bindings will be written
+  --interface-file     If set, generates a `<service-name>.d.ts` file that
+                       contains the same types of the `<service-name>.ts` file.
+                       (default: false)
+  --declarations-only  If set, only generates the declarations folder, skipping
+                       the actor file (index.ts) and service wrapper file
+                       (<service-name>.ts). (default: false)
+  -h, --help           display help for command

--- a/tests/assets/snapshots/cli/help.snapshot
+++ b/tests/assets/snapshots/cli/help.snapshot
@@ -3,14 +3,14 @@ Usage: icp-bindgen [options]
 Generate JavaScript bindings for IC canisters
 
 Options:
-  -V, --version      output the version number
-  --did-file <path>  Path to the .did file to generate bindings from
-  --out-dir <dir>    Directory where the bindings will be written
-  --interface-file   If set, generates a `<service-name>.d.ts` file that
-                     contains the same types of the `<service-name>.ts` file.
-                     Cannot be used with `--disable-actor`. (default: false)
-  --disable-actor    If set, only generates the declarations folder, skipping
-                     the actor file (index.ts) and service wrapper file
-                     (<service-name>.ts). Cannot be used with
-                     `--interface-file`. (default: false)
-  -h, --help         display help for command
+  -V, --version           output the version number
+  --did-file <path>       Path to the .did file to generate bindings from
+  --out-dir <dir>         Directory where the bindings will be written
+  --actor-disabled        If set, only generates the declarations folder,
+                          skipping the actor file (index.ts) and service wrapper
+                          file (<service-name>.ts). (default: false)
+  --actor-interface-file  If set, generates a `<service-name>.d.ts` file that
+                          contains the same types of the `<service-name>.ts`
+                          file. Has no effect if `--actor-disabled` is set.
+                          (default: false)
+  -h, --help              display help for command

--- a/tests/assets/snapshots/cli/help.snapshot
+++ b/tests/assets/snapshots/cli/help.snapshot
@@ -3,15 +3,14 @@ Usage: icp-bindgen [options]
 Generate JavaScript bindings for IC canisters
 
 Options:
-  -V, --version        output the version number
-  --did-file <path>    Path to the .did file to generate bindings from
-  --out-dir <dir>      Directory where the bindings will be written
-  --interface-file     If set, generates a `<service-name>.d.ts` file that
-                       contains the same types of the `<service-name>.ts` file.
-                       Cannot be used with `--declarations-only`. (default:
-                       false)
-  --declarations-only  If set, only generates the declarations folder, skipping
-                       the actor file (index.ts) and service wrapper file
-                       (<service-name>.ts). Cannot be used with
-                       `--interface-file`. (default: false)
-  -h, --help           display help for command
+  -V, --version      output the version number
+  --did-file <path>  Path to the .did file to generate bindings from
+  --out-dir <dir>    Directory where the bindings will be written
+  --interface-file   If set, generates a `<service-name>.d.ts` file that
+                     contains the same types of the `<service-name>.ts` file.
+                     Cannot be used with `--disable-actor`. (default: false)
+  --disable-actor    If set, only generates the declarations folder, skipping
+                     the actor file (index.ts) and service wrapper file
+                     (<service-name>.ts). Cannot be used with
+                     `--interface-file`. (default: false)
+  -h, --help         display help for command

--- a/tests/assets/snapshots/cli/help.snapshot
+++ b/tests/assets/snapshots/cli/help.snapshot
@@ -8,8 +8,10 @@ Options:
   --out-dir <dir>      Directory where the bindings will be written
   --interface-file     If set, generates a `<service-name>.d.ts` file that
                        contains the same types of the `<service-name>.ts` file.
-                       (default: false)
+                       Cannot be used with `--declarations-only`. (default:
+                       false)
   --declarations-only  If set, only generates the declarations folder, skipping
                        the actor file (index.ts) and service wrapper file
-                       (<service-name>.ts). (default: false)
+                       (<service-name>.ts). Cannot be used with
+                       `--interface-file`. (default: false)
   -h, --help           display help for command

--- a/tests/generate.test.ts
+++ b/tests/generate.test.ts
@@ -61,7 +61,7 @@ describe('generate', () => {
       await generate({
         didFile,
         outDir: OUTPUT_DIR,
-        output: { declarationsOnly: true },
+        output: { disableActor: true },
       });
 
       await expectGeneratedDeclarations(SNAPSHOTS_DIR, serviceName);
@@ -80,9 +80,9 @@ describe('generate', () => {
         generate({
           didFile,
           outDir: OUTPUT_DIR,
-          output: { declarationsOnly: true, interfaceFile: true },
+          output: { disableActor: true, interfaceFile: true },
         }),
-      ).rejects.toThrow('Cannot generate an interface file when generating the declarations only');
+      ).rejects.toThrow('Cannot generate an interface file when generating the actor is disabled');
 
       expect(fileExists(`${OUTPUT_DIR}/${serviceName}/declarations/${serviceName}.did.d.ts`)).toBe(
         false,

--- a/tests/generate.test.ts
+++ b/tests/generate.test.ts
@@ -38,7 +38,11 @@ describe('generate', () => {
     async (serviceName) => {
       const didFile = `${TESTS_ASSETS_DIR}/${serviceName}.did`;
 
-      await generate({ didFile, outDir: OUTPUT_DIR, interfaceDeclaration: true });
+      await generate({
+        didFile,
+        outDir: OUTPUT_DIR,
+        output: { interfaceFile: true },
+      });
 
       await expectGeneratedOutput(SNAPSHOTS_DIR, serviceName);
 
@@ -48,6 +52,77 @@ describe('generate', () => {
       );
     },
   );
+
+  it.each(['hello_world', 'example'])(
+    'should generate a bindgen with declarations only',
+    async (serviceName) => {
+      const didFile = `${TESTS_ASSETS_DIR}/${serviceName}.did`;
+
+      await generate({
+        didFile,
+        outDir: OUTPUT_DIR,
+        output: { declarationsOnly: true },
+      });
+
+      await expectGeneratedDeclarations(SNAPSHOTS_DIR, serviceName);
+      expect(fileExists(`${OUTPUT_DIR}/${serviceName}/${serviceName}.d.ts`)).toBe(false);
+      expect(fileExists(`${OUTPUT_DIR}/${serviceName}/${serviceName}.ts`)).toBe(false);
+      expect(fileExists(`${OUTPUT_DIR}/${serviceName}/index.ts`)).toBe(false);
+    },
+  );
+
+  it.each(['hello_world', 'example'])(
+    'should throw when generating an interface file with declarations only',
+    async (serviceName) => {
+      const didFile = `${TESTS_ASSETS_DIR}/${serviceName}.did`;
+
+      await expect(
+        generate({
+          didFile,
+          outDir: OUTPUT_DIR,
+          output: { declarationsOnly: true, interfaceFile: true },
+        }),
+      ).rejects.toThrow('Cannot generate an interface file when generating the declarations only');
+
+      expect(fileExists(`${OUTPUT_DIR}/${serviceName}/declarations/${serviceName}.did.d.ts`)).toBe(
+        false,
+      );
+      expect(fileExists(`${OUTPUT_DIR}/${serviceName}/declarations/${serviceName}.did.js`)).toBe(
+        false,
+      );
+    },
+  );
+
+  it('should preserve the .did file', async () => {
+    const { readFile: realReadFile } =
+      await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+
+    const serviceName = 'hello_world';
+    const didFile = `${TESTS_ASSETS_DIR}/${serviceName}.did`;
+    const originalDidFileContent = await realReadFile(didFile, 'utf-8');
+
+    // We simulate a .did file in the output directory
+    const didFilePath = `${OUTPUT_DIR}/${serviceName}.did`;
+    vol.mkdirSync(OUTPUT_DIR, { recursive: true });
+    vol.writeFileSync(didFilePath, originalDidFileContent, { encoding: 'utf-8' });
+    // We also add another (unused) .did file to check that all of them are preserved
+    const otherDidFilePath = `${OUTPUT_DIR}/other.did`;
+    vol.writeFileSync(otherDidFilePath, 'other', { encoding: 'utf-8' });
+
+    // Assert before and after the generation
+    expect(fileExists(didFilePath)).toBe(true);
+    expect(fileExists(otherDidFilePath)).toBe(true);
+
+    await generate({
+      // We must use the file that exists in the real filesystem
+      // because wasm reads from the real filesystem
+      didFile,
+      outDir: OUTPUT_DIR,
+    });
+
+    expect(fileExists(didFilePath)).toBe(true);
+    expect(fileExists(otherDidFilePath)).toBe(true);
+  });
 
   it('should generate a bindgen with canister env feature', async () => {
     const helloWorldServiceName = 'hello_world';
@@ -78,7 +153,10 @@ function fileExists(path: string): boolean {
   return vol.existsSync(path);
 }
 
-async function expectGeneratedOutput(snapshotsDir: string, serviceName: string): Promise<void> {
+async function expectGeneratedDeclarations(
+  snapshotsDir: string,
+  serviceName: string,
+): Promise<void> {
   const generatedOutputDir = join(snapshotsDir, serviceName);
   const generatedOutputDeclarationsDir = join(generatedOutputDir, 'declarations');
 
@@ -91,6 +169,12 @@ async function expectGeneratedOutput(snapshotsDir: string, serviceName: string):
   await expect(declarationsTs).toMatchFileSnapshot(
     `${generatedOutputDeclarationsDir}/${serviceName}.did.d.ts.snapshot`,
   );
+}
+
+async function expectGeneratedOutput(snapshotsDir: string, serviceName: string): Promise<void> {
+  const generatedOutputDir = join(snapshotsDir, serviceName);
+
+  await expectGeneratedDeclarations(snapshotsDir, serviceName);
 
   const serviceTs = await readFileFromOutput(`${serviceName}.ts`);
   await expect(serviceTs).toMatchFileSnapshot(`${generatedOutputDir}/${serviceName}.ts.snapshot`);


### PR DESCRIPTION
Introduces the `output` option to better control what files are generated.

Moves the `interfaceDeclaration` into it as `output.actor.interfaceFile` and adds the `output.actor.disable` flag.

Additionally, it fixes the bug when the `.did` file is read from the output directory.
