### PR TITLE
fix: use interface in type declarations

### DIFF
--- a/src/core/generate/rs/src/bindings/typescript_native/compile_interface.rs
+++ b/src/core/generate/rs/src/bindings/typescript_native/compile_interface.rs
@@ -1,5 +1,7 @@
 use super::conversion_functions_generator::TypeConverter;
-use super::new_typescript_native_types::{add_type_definitions, create_interface_from_service};
+use super::new_typescript_native_types::{
+    add_type_definitions, create_interface_from_service, service_interface_ident,
+};
 use super::preamble::imports::interface_imports;
 use super::preamble::options::interface_options_utils;
 use super::utils::EnumDeclarations;
@@ -161,14 +163,11 @@ pub fn interface_actor_var(module: &mut Module, type_id: &str, service_name: &st
     let interface = TsInterfaceDecl {
         span: DUMMY_SP,
         declare: false,
-        id: get_ident_guarded(&format!("{}Interface", service_name)),
+        id: service_interface_ident(service_name),
         type_params: None,
         extends: vec![TsExprWithTypeArgs {
             span: DUMMY_SP,
-            expr: Box::new(Expr::Ident(get_ident_guarded(&format!(
-                "{}Interface",
-                type_id
-            )))),
+            expr: Box::new(Expr::Ident(service_interface_ident(type_id))),
             type_args: None,
         }],
         body: TsInterfaceBody {
@@ -185,12 +184,6 @@ pub fn interface_actor_var(module: &mut Module, type_id: &str, service_name: &st
 }
 
 fn add_create_actor_interface_exports(module: &mut Module, service_name: &str) {
-    let capitalized_service_name = service_name
-        .chars()
-        .next()
-        .map_or(String::new(), |c| c.to_uppercase().collect::<String>())
-        + &service_name[1..];
-
     let type_process_error_fn = super::preamble::actor::process_error_fn_type();
     module
         .body
@@ -283,7 +276,7 @@ fn add_create_actor_interface_exports(module: &mut Module, service_name: &str) {
                 span: DUMMY_SP,
                 type_ann: Box::new(TsType::TsTypeRef(TsTypeRef {
                     span: DUMMY_SP,
-                    type_name: TsEntityName::Ident(get_ident_guarded(&capitalized_service_name)),
+                    type_name: TsEntityName::Ident(service_interface_ident(service_name)),
                     type_params: None,
                 })),
             })),

--- a/src/core/generate/rs/src/bindings/typescript_native/compile_wrapper.rs
+++ b/src/core/generate/rs/src/bindings/typescript_native/compile_wrapper.rs
@@ -7,7 +7,7 @@ use swc_core::common::{DUMMY_SP, SyntaxContext};
 use swc_core::ecma::ast::*;
 
 use super::conversion_functions_generator::convert_multi_return_from_candid;
-use super::new_typescript_native_types::convert_type_with_converter;
+use super::new_typescript_native_types::{convert_type_with_converter, service_interface_ident};
 
 use super::new_typescript_native_types::add_type_definitions;
 use super::preamble::imports::wrapper_imports;
@@ -377,10 +377,7 @@ fn create_actor_class(
             super_type_params: None,
             implements: vec![TsExprWithTypeArgs {
                 span: DUMMY_SP,
-                expr: Box::new(Expr::Ident(get_ident_guarded(&format!(
-                    "{}Interface",
-                    service_name
-                )))),
+                expr: Box::new(Expr::Ident(service_interface_ident(service_name))),
                 type_args: None,
             }],
             is_abstract: false,

--- a/src/core/generate/rs/src/bindings/typescript_native/new_typescript_native_types.rs
+++ b/src/core/generate/rs/src/bindings/typescript_native/new_typescript_native_types.rs
@@ -47,7 +47,7 @@ pub fn is_recursive_optional(
 pub fn create_interface_from_service(
     top_level_nodes: &mut TopLevelNodes,
     env: &TypeEnv,
-    id: &str,
+    service_name: &str,
     syntax: Option<&IDLType>,
     serv: &[(String, Type)],
 ) -> TsInterfaceDecl {
@@ -90,7 +90,7 @@ pub fn create_interface_from_service(
     TsInterfaceDecl {
         span: DUMMY_SP,
         declare: false,
-        id: get_ident_guarded(&format!("{}Interface", id)),
+        id: service_interface_ident(service_name),
         type_params: None,
         extends: vec![],
         body: TsInterfaceBody {
@@ -701,8 +701,8 @@ pub fn add_type_definitions(
                 TypeInner::Var(inner_id) => {
                     let inner_type = env.rec_find_type(inner_id).unwrap();
                     let inner_name = match inner_type.as_ref() {
-                        TypeInner::Service(_) => format!("{}Interface", inner_id),
-                        _ => inner_id.as_str().to_string(),
+                        TypeInner::Service(_) => service_interface_ident(inner_id.as_str()),
+                        _ => get_ident_guarded(inner_id.as_str()),
                     };
                     let type_alias = TsTypeAliasDecl {
                         span: DUMMY_SP,
@@ -711,7 +711,7 @@ pub fn add_type_definitions(
                         type_params: None,
                         type_ann: Box::new(TsType::TsTypeRef(TsTypeRef {
                             span: DUMMY_SP,
-                            type_name: TsEntityName::Ident(get_ident_guarded(&inner_name)),
+                            type_name: TsEntityName::Ident(inner_name),
                             type_params: None,
                         })),
                     };
@@ -1102,4 +1102,8 @@ fn create_function_type_ref() -> TsType {
         })
         .collect(),
     })
+}
+
+pub fn service_interface_ident(service_name: &str) -> Ident {
+    get_ident_guarded(&format!("{}Interface", service_name))
 }

--- a/tests/snapshots/generate/example/example.d.ts.snapshot
+++ b/tests/snapshots/generate/example/example.d.ts.snapshot
@@ -215,4 +215,4 @@ export interface CreateActorOptions {
     agentOptions?: HttpAgentOptions;
     actorOptions?: ActorConfig;
 }
-export declare function createActor(canisterId: string, options: CreateActorOptions = {}, processError?: ProcessErrorFn): Example;
+export declare function createActor(canisterId: string, options: CreateActorOptions = {}, processError?: ProcessErrorFn): exampleInterface;

--- a/tests/snapshots/generate/hello_world/hello_world.d.ts.snapshot
+++ b/tests/snapshots/generate/hello_world/hello_world.d.ts.snapshot
@@ -26,4 +26,4 @@ export interface CreateActorOptions {
     agentOptions?: HttpAgentOptions;
     actorOptions?: ActorConfig;
 }
-export declare function createActor(canisterId: string, options: CreateActorOptions = {}, processError?: ProcessErrorFn): Hello_world;
+export declare function createActor(canisterId: string, options: CreateActorOptions = {}, processError?: ProcessErrorFn): hello_worldInterface;

--- a/tests/snapshots/wasm-generate/example/example.d.ts.snapshot
+++ b/tests/snapshots/wasm-generate/example/example.d.ts.snapshot
@@ -207,4 +207,4 @@ export interface CreateActorOptions {
     agentOptions?: HttpAgentOptions;
     actorOptions?: ActorConfig;
 }
-export declare function createActor(canisterId: string, options: CreateActorOptions = {}, processError?: ProcessErrorFn): Example;
+export declare function createActor(canisterId: string, options: CreateActorOptions = {}, processError?: ProcessErrorFn): exampleInterface;

--- a/tests/snapshots/wasm-generate/hello_world/hello_world.d.ts.snapshot
+++ b/tests/snapshots/wasm-generate/hello_world/hello_world.d.ts.snapshot
@@ -18,4 +18,4 @@ export interface CreateActorOptions {
     agentOptions?: HttpAgentOptions;
     actorOptions?: ActorConfig;
 }
-export declare function createActor(canisterId: string, options: CreateActorOptions = {}, processError?: ProcessErrorFn): Hello_world;
+export declare function createActor(canisterId: string, options: CreateActorOptions = {}, processError?: ProcessErrorFn): hello_worldInterface;


### PR DESCRIPTION
Declares the `createActor` function return type using the interface instead of the actual class name.
