### PR TITLE
fix: improve logs

### DIFF
--- a/src/cli/icp-bindgen.ts
+++ b/src/cli/icp-bindgen.ts
@@ -64,7 +64,7 @@ type Args = {
 async function run(args: Args) {
   const { didFile, outDir, actorInterfaceFile, actorDisabled, force } = args;
 
-  console.log(cyan(`[${BIN_NAME}] Generating bindings...`));
+  console.log(cyan(`[${BIN_NAME}] Generating bindings from`), green(didFile));
   await generate({
     didFile,
     outDir,
@@ -76,7 +76,7 @@ async function run(args: Args) {
       },
     },
   });
-  console.log(cyan(`[${BIN_NAME}] Generated bindings successfully at`), green(outDir));
+  console.log(cyan(`[${BIN_NAME}] Bindings generated at`), green(outDir));
 }
 
 const program = new Command();

--- a/src/plugins/vite.ts
+++ b/src/plugins/vite.ts
@@ -115,7 +115,7 @@ function watchDidFileChanges(server: ViteDevServer, options: Options) {
 }
 
 async function run(options: Options) {
-  console.log(cyan(`[${VITE_PLUGIN_NAME}] Generating bindings...`));
+  console.log(cyan(`[${VITE_PLUGIN_NAME}] Generating bindings from`), green(options.didFile));
 
   await generate({
     didFile: options.didFile,
@@ -128,8 +128,5 @@ async function run(options: Options) {
     additionalFeatures: options.additionalFeatures,
   });
 
-  console.log(
-    cyan(`[${VITE_PLUGIN_NAME}] Generated bindings successfully at`),
-    green(options.outDir),
-  );
+  console.log(cyan(`[${VITE_PLUGIN_NAME}] Bindings generated at`), green(options.outDir));
 }


### PR DESCRIPTION
Prints the did file path in the first log message and makes the success message shorter.
