### PR TITLE
fix: doc comment above the variant field

### DIFF
--- a/src/core/generate/rs/src/bindings/typescript_native/comments.rs
+++ b/src/core/generate/rs/src/bindings/typescript_native/comments.rs
@@ -42,10 +42,6 @@ fn make_comment(docs: &[String]) -> Option<Comment> {
             span: DUMMY_SP,
             kind: CommentKind::Block,
             text: comment_text.into(),
-            // swc_core 0.80+ uses None for comments attached to no specific position
-            // If you want to attach to leading, set as Some(true)
-            // For now, we use None
-            // has_trailing_newline: false, // Only in newer swc
         })
     }
 }

--- a/src/core/generate/rs/src/bindings/typescript_native/new_typescript_native_types.rs
+++ b/src/core/generate/rs/src/bindings/typescript_native/new_typescript_native_types.rs
@@ -567,7 +567,7 @@ fn create_variant_type(
 
                         // Create the __kind__ property
                         let kind_prop = TsTypeElement::TsPropertySignature(TsPropertySignature {
-                            span,
+                            span: DUMMY_SP,
                             readonly: false,
                             key: Box::new(Expr::Ident(Ident::new(
                                 "__kind__".into(),
@@ -589,12 +589,13 @@ fn create_variant_type(
                             })),
                         });
 
-                        // Create the value property
+                        // Create the value property (with doc comment)
                         let value_prop = create_property_signature_for_variant(
                             top_level_nodes,
                             env,
                             f,
                             syntax_field_ty,
+                            span,
                         );
 
                         Box::new(TsType::TsTypeLit(TsTypeLit {
@@ -874,6 +875,7 @@ fn create_property_signature_for_variant(
     env: &TypeEnv,
     field: &Field,
     syntax: Option<&IDLType>,
+    span: Span,
 ) -> TsTypeElement {
     let field_name = match &*field.id {
         Label::Named(str) => Box::new(Expr::Ident(get_ident_guarded_keyword_ok(str))),
@@ -913,7 +915,7 @@ fn create_property_signature_for_variant(
     };
 
     TsTypeElement::TsPropertySignature(TsPropertySignature {
-        span: DUMMY_SP,
+        span,
         readonly: false,
         key: field_name,
         computed: false,

--- a/tests/snapshots/generate/example/example.d.ts.snapshot
+++ b/tests/snapshots/generate/example/example.d.ts.snapshot
@@ -18,10 +18,10 @@ export interface None {
 }
 export type Option<T> = Some<T> | None;
 export type my_variant = {
+    __kind__: "a";
     /**
      * Doc comment for my_variant field a
     */
-    __kind__: "a";
     a: {
         /**
          * Doc comment for my_variant field a field b
@@ -29,10 +29,10 @@ export type my_variant = {
         b: string;
     };
 } | {
+    __kind__: "c";
     /**
      * Doc comment for my_variant field c
     */
-    __kind__: "c";
     c: {
         d: string;
         e: Array<{
@@ -57,16 +57,16 @@ export interface nested {
     _42_: bigint;
 }
 export type res = {
+    __kind__: "Ok";
     /**
      * Doc comment for Ok variant
     */
-    __kind__: "Ok";
     Ok: [bigint, bigint];
 } | {
+    __kind__: "Err";
     /**
      * Doc comment for Err variant
     */
-    __kind__: "Err";
     Err: {
         /**
          * Doc comment for error field in Err variant,
@@ -86,18 +86,18 @@ export type nested_res = {
 } | {
     __kind__: "Err";
     Err: {
+        __kind__: "Ok";
         /**
          * Doc comment for Ok in nested variant
         */
-        __kind__: "Ok";
         Ok: {
             content: string;
         };
     } | {
+        __kind__: "Err";
         /**
          * Doc comment for Err in nested variant
         */
-        __kind__: "Err";
         Err: [bigint];
     };
 };

--- a/tests/snapshots/generate/example/example.ts.snapshot
+++ b/tests/snapshots/generate/example/example.ts.snapshot
@@ -52,10 +52,10 @@ function record_opt_to_undefined<T>(arg: T | null): T | undefined {
     return arg == null ? undefined : arg;
 }
 export type my_variant = {
+    __kind__: "a";
     /**
      * Doc comment for my_variant field a
     */
-    __kind__: "a";
     a: {
         /**
          * Doc comment for my_variant field a field b
@@ -63,10 +63,10 @@ export type my_variant = {
         b: string;
     };
 } | {
+    __kind__: "c";
     /**
      * Doc comment for my_variant field c
     */
-    __kind__: "c";
     c: {
         d: string;
         e: Array<{
@@ -91,16 +91,16 @@ export interface nested {
     _42_: bigint;
 }
 export type res = {
+    __kind__: "Ok";
     /**
      * Doc comment for Ok variant
     */
-    __kind__: "Ok";
     Ok: [bigint, bigint];
 } | {
+    __kind__: "Err";
     /**
      * Doc comment for Err variant
     */
-    __kind__: "Err";
     Err: {
         /**
          * Doc comment for error field in Err variant,
@@ -120,18 +120,18 @@ export type nested_res = {
 } | {
     __kind__: "Err";
     Err: {
+        __kind__: "Ok";
         /**
          * Doc comment for Ok in nested variant
         */
-        __kind__: "Ok";
         Ok: {
             content: string;
         };
     } | {
+        __kind__: "Err";
         /**
          * Doc comment for Err in nested variant
         */
-        __kind__: "Err";
         Err: [bigint];
     };
 };

--- a/tests/snapshots/wasm-generate/example/example.d.ts.snapshot
+++ b/tests/snapshots/wasm-generate/example/example.d.ts.snapshot
@@ -10,10 +10,10 @@ export interface None {
 }
 export type Option<T> = Some<T> | None;
 export type my_variant = {
+    __kind__: "a";
     /**
      * Doc comment for my_variant field a
     */
-    __kind__: "a";
     a: {
         /**
          * Doc comment for my_variant field a field b
@@ -21,10 +21,10 @@ export type my_variant = {
         b: string;
     };
 } | {
+    __kind__: "c";
     /**
      * Doc comment for my_variant field c
     */
-    __kind__: "c";
     c: {
         d: string;
         e: Array<{
@@ -49,16 +49,16 @@ export interface nested {
     _42_: bigint;
 }
 export type res = {
+    __kind__: "Ok";
     /**
      * Doc comment for Ok variant
     */
-    __kind__: "Ok";
     Ok: [bigint, bigint];
 } | {
+    __kind__: "Err";
     /**
      * Doc comment for Err variant
     */
-    __kind__: "Err";
     Err: {
         /**
          * Doc comment for error field in Err variant,
@@ -78,18 +78,18 @@ export type nested_res = {
 } | {
     __kind__: "Err";
     Err: {
+        __kind__: "Ok";
         /**
          * Doc comment for Ok in nested variant
         */
-        __kind__: "Ok";
         Ok: {
             content: string;
         };
     } | {
+        __kind__: "Err";
         /**
          * Doc comment for Err in nested variant
         */
-        __kind__: "Err";
         Err: [bigint];
     };
 };

--- a/tests/snapshots/wasm-generate/example/example.ts.snapshot
+++ b/tests/snapshots/wasm-generate/example/example.ts.snapshot
@@ -44,10 +44,10 @@ function record_opt_to_undefined<T>(arg: T | null): T | undefined {
     return arg == null ? undefined : arg;
 }
 export type my_variant = {
+    __kind__: "a";
     /**
      * Doc comment for my_variant field a
     */
-    __kind__: "a";
     a: {
         /**
          * Doc comment for my_variant field a field b
@@ -55,10 +55,10 @@ export type my_variant = {
         b: string;
     };
 } | {
+    __kind__: "c";
     /**
      * Doc comment for my_variant field c
     */
-    __kind__: "c";
     c: {
         d: string;
         e: Array<{
@@ -83,16 +83,16 @@ export interface nested {
     _42_: bigint;
 }
 export type res = {
+    __kind__: "Ok";
     /**
      * Doc comment for Ok variant
     */
-    __kind__: "Ok";
     Ok: [bigint, bigint];
 } | {
+    __kind__: "Err";
     /**
      * Doc comment for Err variant
     */
-    __kind__: "Err";
     Err: {
         /**
          * Doc comment for error field in Err variant,
@@ -112,18 +112,18 @@ export type nested_res = {
 } | {
     __kind__: "Err";
     Err: {
+        __kind__: "Ok";
         /**
          * Doc comment for Ok in nested variant
         */
-        __kind__: "Ok";
         Ok: {
             content: string;
         };
     } | {
+        __kind__: "Err";
         /**
          * Doc comment for Err in nested variant
         */
-        __kind__: "Err";
         Err: [bigint];
     };
 };


### PR DESCRIPTION
In variants, move doc comments above variant fields.
