### PR TITLE
fix: add space at the end of the doc comment

### DIFF
--- a/src/core/generate/rs/src/bindings/typescript_native/comments.rs
+++ b/src/core/generate/rs/src/bindings/typescript_native/comments.rs
@@ -1,7 +1,7 @@
 use super::conversion_functions_generator::TopLevelNodes;
 use swc_core::common::{
     BytePos, DUMMY_SP, Span,
-    comments::{Comment, CommentKind},
+    comments::{Comment, CommentKind, Comments},
 };
 
 // Simple monotonic position source for synthetic spans
@@ -24,19 +24,13 @@ fn make_comment(docs: &[String]) -> Option<Comment> {
         None
     } else {
         // Join all doc lines into a single block comment, with each line prefixed by a space
-        let mut comment_text = String::new();
-        comment_text.push_str("*\n");
+        let mut comment_text = String::from("*\n");
         for line in docs {
-            comment_text.push(' ');
-            comment_text.push_str(&format!("* {}", line));
-            comment_text.push('\n');
-        }
-        // Remove trailing newline
-        if comment_text.ends_with('\n') {
-            comment_text.pop();
+            comment_text.push_str(&format!(" * {}\n", line));
         }
 
-        comment_text.push('\n');
+        // Add a space at the end to align the block comment final line ("*/") properly
+        comment_text.push(' ');
 
         Some(Comment {
             span: DUMMY_SP,
@@ -47,7 +41,6 @@ fn make_comment(docs: &[String]) -> Option<Comment> {
 }
 
 pub fn add_comments(top_level_nodes: &mut TopLevelNodes, docs: &[String]) -> Span {
-    use swc_core::common::comments::Comments;
     let (_, comments, cursor) = top_level_nodes;
     match docs.len() {
         0 => DUMMY_SP,

--- a/tests/snapshots/generate/example/example.d.ts.snapshot
+++ b/tests/snapshots/generate/example/example.d.ts.snapshot
@@ -21,18 +21,18 @@ export type my_variant = {
     __kind__: "a";
     /**
      * Doc comment for my_variant field a
-    */
+     */
     a: {
         /**
          * Doc comment for my_variant field a field b
-        */
+         */
         b: string;
     };
 } | {
     __kind__: "c";
     /**
      * Doc comment for my_variant field c
-    */
+     */
     c: {
         d: string;
         e: Array<{
@@ -45,7 +45,7 @@ export interface nested {
     _1_: bigint;
     /**
      * Doc comment for nested record
-    */
+     */
     _2_: [bigint, bigint];
     _3_: {
         _0_: bigint;
@@ -60,18 +60,18 @@ export type res = {
     __kind__: "Ok";
     /**
      * Doc comment for Ok variant
-    */
+     */
     Ok: [bigint, bigint];
 } | {
     __kind__: "Err";
     /**
      * Doc comment for Err variant
-    */
+     */
     Err: {
         /**
          * Doc comment for error field in Err variant,
          * on multiple lines
-        */
+         */
         error: string;
     };
 };
@@ -89,7 +89,7 @@ export type nested_res = {
         __kind__: "Ok";
         /**
          * Doc comment for Ok in nested variant
-        */
+         */
         Ok: {
             content: string;
         };
@@ -97,7 +97,7 @@ export type nested_res = {
         __kind__: "Err";
         /**
          * Doc comment for Err in nested variant
-        */
+         */
         Err: [bigint];
     };
 };
@@ -116,7 +116,7 @@ export type tree = {
 export interface nested_records {
     /**
      * Doc comment for nested_records field nested
-    */
+     */
     nested?: {
         nested_field: string;
     };
@@ -128,11 +128,11 @@ export interface brokerInterface {
 export type list = node | null;
 /**
  * Doc comment for prim type
-*/
+ */
 export type my_type = Principal;
 /**
  * Doc comment for List
-*/
+ */
 export type List = {
     head: bigint;
     tail: List;
@@ -170,11 +170,11 @@ export enum Variant_a_b {
 }
 /**
  * Doc comment for service
-*/
+ */
 export interface exampleInterface {
     /**
      * Doc comment for f1 method of service
-    */
+     */
     f1(arg0: list, test: Uint8Array | number[], arg2: boolean | null): Promise<void>;
     g1(arg0: my_type, arg1: List, arg2: List | null, arg3: nested): Promise<[bigint, Principal, nested_res]>;
     h(arg0: Array<string | null>, arg1: {
@@ -190,7 +190,7 @@ export interface exampleInterface {
     }>;
     /**
      * Doc comment for i method of service
-    */
+     */
     i: f;
     x(arg0: a, arg1: b): Promise<[a | null, b | null, {
             __kind__: "Ok";
@@ -206,7 +206,7 @@ export interface exampleInterface {
     g(arg0: list): Promise<[B, tree, stream]>;
     /**
      * Doc comment for imported bbbbb service method
-    */
+     */
     bbbbb(arg0: b): Promise<void>;
 }
 export type ProcessErrorFn = (error: unknown) => never;

--- a/tests/snapshots/generate/example/example.ts.snapshot
+++ b/tests/snapshots/generate/example/example.ts.snapshot
@@ -55,18 +55,18 @@ export type my_variant = {
     __kind__: "a";
     /**
      * Doc comment for my_variant field a
-    */
+     */
     a: {
         /**
          * Doc comment for my_variant field a field b
-        */
+         */
         b: string;
     };
 } | {
     __kind__: "c";
     /**
      * Doc comment for my_variant field c
-    */
+     */
     c: {
         d: string;
         e: Array<{
@@ -79,7 +79,7 @@ export interface nested {
     _1_: bigint;
     /**
      * Doc comment for nested record
-    */
+     */
     _2_: [bigint, bigint];
     _3_: {
         _0_: bigint;
@@ -94,18 +94,18 @@ export type res = {
     __kind__: "Ok";
     /**
      * Doc comment for Ok variant
-    */
+     */
     Ok: [bigint, bigint];
 } | {
     __kind__: "Err";
     /**
      * Doc comment for Err variant
-    */
+     */
     Err: {
         /**
          * Doc comment for error field in Err variant,
          * on multiple lines
-        */
+         */
         error: string;
     };
 };
@@ -123,7 +123,7 @@ export type nested_res = {
         __kind__: "Ok";
         /**
          * Doc comment for Ok in nested variant
-        */
+         */
         Ok: {
             content: string;
         };
@@ -131,7 +131,7 @@ export type nested_res = {
         __kind__: "Err";
         /**
          * Doc comment for Err in nested variant
-        */
+         */
         Err: [bigint];
     };
 };
@@ -150,7 +150,7 @@ export type tree = {
 export interface nested_records {
     /**
      * Doc comment for nested_records field nested
-    */
+     */
     nested?: {
         nested_field: string;
     };
@@ -162,11 +162,11 @@ export interface brokerInterface {
 export type list = node | null;
 /**
  * Doc comment for prim type
-*/
+ */
 export type my_type = Principal;
 /**
  * Doc comment for List
-*/
+ */
 export type List = {
     head: bigint;
     tail: List;
@@ -205,11 +205,11 @@ export enum Variant_a_b {
 export type ProcessErrorFn = (error: unknown) => never;
 /**
  * Doc comment for service
-*/
+ */
 export interface exampleInterface {
     /**
      * Doc comment for f1 method of service
-    */
+     */
     f1(arg0: list, test: Uint8Array | number[], arg2: boolean | null): Promise<void>;
     g1(arg0: my_type, arg1: List, arg2: List | null, arg3: nested): Promise<[bigint, Principal, nested_res]>;
     h(arg0: Array<string | null>, arg1: {
@@ -225,7 +225,7 @@ export interface exampleInterface {
     }>;
     /**
      * Doc comment for i method of service
-    */
+     */
     i: f;
     x(arg0: a, arg1: b): Promise<[a | null, b | null, {
             __kind__: "Ok";
@@ -241,7 +241,7 @@ export interface exampleInterface {
     g(arg0: list): Promise<[B, tree, stream]>;
     /**
      * Doc comment for imported bbbbb service method
-    */
+     */
     bbbbb(arg0: b): Promise<void>;
 }
 import type { A as _A, B as _B, List as _List, a as _a, b as _b, list as _list, my_variant as _my_variant, nested as _nested, nested_records as _nested_records, nested_res as _nested_res, node as _node, res as _res, stream as _stream, tree as _tree } from "./declarations/example.did.d.ts";

--- a/tests/snapshots/wasm-generate/example/example.d.ts.snapshot
+++ b/tests/snapshots/wasm-generate/example/example.d.ts.snapshot
@@ -13,18 +13,18 @@ export type my_variant = {
     __kind__: "a";
     /**
      * Doc comment for my_variant field a
-    */
+     */
     a: {
         /**
          * Doc comment for my_variant field a field b
-        */
+         */
         b: string;
     };
 } | {
     __kind__: "c";
     /**
      * Doc comment for my_variant field c
-    */
+     */
     c: {
         d: string;
         e: Array<{
@@ -37,7 +37,7 @@ export interface nested {
     _1_: bigint;
     /**
      * Doc comment for nested record
-    */
+     */
     _2_: [bigint, bigint];
     _3_: {
         _0_: bigint;
@@ -52,18 +52,18 @@ export type res = {
     __kind__: "Ok";
     /**
      * Doc comment for Ok variant
-    */
+     */
     Ok: [bigint, bigint];
 } | {
     __kind__: "Err";
     /**
      * Doc comment for Err variant
-    */
+     */
     Err: {
         /**
          * Doc comment for error field in Err variant,
          * on multiple lines
-        */
+         */
         error: string;
     };
 };
@@ -81,7 +81,7 @@ export type nested_res = {
         __kind__: "Ok";
         /**
          * Doc comment for Ok in nested variant
-        */
+         */
         Ok: {
             content: string;
         };
@@ -89,7 +89,7 @@ export type nested_res = {
         __kind__: "Err";
         /**
          * Doc comment for Err in nested variant
-        */
+         */
         Err: [bigint];
     };
 };
@@ -108,7 +108,7 @@ export type tree = {
 export interface nested_records {
     /**
      * Doc comment for nested_records field nested
-    */
+     */
     nested?: {
         nested_field: string;
     };
@@ -120,11 +120,11 @@ export interface brokerInterface {
 export type list = node | null;
 /**
  * Doc comment for prim type
-*/
+ */
 export type my_type = Principal;
 /**
  * Doc comment for List
-*/
+ */
 export type List = {
     head: bigint;
     tail: List;
@@ -162,11 +162,11 @@ export enum Variant_a_b {
 }
 /**
  * Doc comment for service
-*/
+ */
 export interface exampleInterface {
     /**
      * Doc comment for f1 method of service
-    */
+     */
     f1(arg0: list, test: Uint8Array | number[], arg2: boolean | null): Promise<void>;
     g1(arg0: my_type, arg1: List, arg2: List | null, arg3: nested): Promise<[bigint, Principal, nested_res]>;
     h(arg0: Array<string | null>, arg1: {
@@ -182,7 +182,7 @@ export interface exampleInterface {
     }>;
     /**
      * Doc comment for i method of service
-    */
+     */
     i: f;
     x(arg0: a, arg1: b): Promise<[a | null, b | null, {
             __kind__: "Ok";
@@ -198,7 +198,7 @@ export interface exampleInterface {
     g(arg0: list): Promise<[B, tree, stream]>;
     /**
      * Doc comment for imported bbbbb service method
-    */
+     */
     bbbbb(arg0: b): Promise<void>;
 }
 export type ProcessErrorFn = (error: unknown) => never;

--- a/tests/snapshots/wasm-generate/example/example.ts.snapshot
+++ b/tests/snapshots/wasm-generate/example/example.ts.snapshot
@@ -47,18 +47,18 @@ export type my_variant = {
     __kind__: "a";
     /**
      * Doc comment for my_variant field a
-    */
+     */
     a: {
         /**
          * Doc comment for my_variant field a field b
-        */
+         */
         b: string;
     };
 } | {
     __kind__: "c";
     /**
      * Doc comment for my_variant field c
-    */
+     */
     c: {
         d: string;
         e: Array<{
@@ -71,7 +71,7 @@ export interface nested {
     _1_: bigint;
     /**
      * Doc comment for nested record
-    */
+     */
     _2_: [bigint, bigint];
     _3_: {
         _0_: bigint;
@@ -86,18 +86,18 @@ export type res = {
     __kind__: "Ok";
     /**
      * Doc comment for Ok variant
-    */
+     */
     Ok: [bigint, bigint];
 } | {
     __kind__: "Err";
     /**
      * Doc comment for Err variant
-    */
+     */
     Err: {
         /**
          * Doc comment for error field in Err variant,
          * on multiple lines
-        */
+         */
         error: string;
     };
 };
@@ -115,7 +115,7 @@ export type nested_res = {
         __kind__: "Ok";
         /**
          * Doc comment for Ok in nested variant
-        */
+         */
         Ok: {
             content: string;
         };
@@ -123,7 +123,7 @@ export type nested_res = {
         __kind__: "Err";
         /**
          * Doc comment for Err in nested variant
-        */
+         */
         Err: [bigint];
     };
 };
@@ -142,7 +142,7 @@ export type tree = {
 export interface nested_records {
     /**
      * Doc comment for nested_records field nested
-    */
+     */
     nested?: {
         nested_field: string;
     };
@@ -154,11 +154,11 @@ export interface brokerInterface {
 export type list = node | null;
 /**
  * Doc comment for prim type
-*/
+ */
 export type my_type = Principal;
 /**
  * Doc comment for List
-*/
+ */
 export type List = {
     head: bigint;
     tail: List;
@@ -197,11 +197,11 @@ export enum Variant_a_b {
 export type ProcessErrorFn = (error: unknown) => never;
 /**
  * Doc comment for service
-*/
+ */
 export interface exampleInterface {
     /**
      * Doc comment for f1 method of service
-    */
+     */
     f1(arg0: list, test: Uint8Array | number[], arg2: boolean | null): Promise<void>;
     g1(arg0: my_type, arg1: List, arg2: List | null, arg3: nested): Promise<[bigint, Principal, nested_res]>;
     h(arg0: Array<string | null>, arg1: {
@@ -217,7 +217,7 @@ export interface exampleInterface {
     }>;
     /**
      * Doc comment for i method of service
-    */
+     */
     i: f;
     x(arg0: a, arg1: b): Promise<[a | null, b | null, {
             __kind__: "Ok";
@@ -233,7 +233,7 @@ export interface exampleInterface {
     g(arg0: list): Promise<[B, tree, stream]>;
     /**
      * Doc comment for imported bbbbb service method
-    */
+     */
     bbbbb(arg0: b): Promise<void>;
 }
 import type { A as _A, B as _B, List as _List, a as _a, b as _b, list as _list, my_variant as _my_variant, nested as _nested, nested_records as _nested_records, nested_res as _nested_res, node as _node, res as _res, stream as _stream, tree as _tree } from "./declarations/example.did.d.ts";


### PR DESCRIPTION
Additionally, simplifies the logic to create a doc comment.
