### PR TITLE
fix: remove unneeded unions on typed arrays

### DIFF
--- a/src/core/generate/rs/src/bindings/typescript.rs
+++ b/src/core/generate/rs/src/bindings/typescript.rs
@@ -133,14 +133,14 @@ fn pp_vec<'a>(
         _ => inner,
     };
     match ty.as_ref() {
-        Nat8 => str("Uint8Array | number[]"),
-        Nat16 => str("Uint16Array | number[]"),
-        Nat32 => str("Uint32Array | number[]"),
-        Nat64 => str("BigUint64Array | bigint[]"),
-        Int8 => str("Int8Array | number[]"),
-        Int16 => str("Int16Array | number[]"),
-        Int32 => str("Int32Array | number[]"),
-        Int64 => str("BigInt64Array | bigint[]"),
+        Nat8 => str("Uint8Array"),
+        Nat16 => str("Uint16Array"),
+        Nat32 => str("Uint32Array"),
+        Nat64 => str("BigUint64Array"),
+        Int8 => str("Int8Array"),
+        Int16 => str("Int16Array"),
+        Int32 => str("Int32Array"),
+        Int64 => str("BigInt64Array"),
         _ => str("Array").append(enclose("<", pp_ty_rich(env, inner, syntax, is_ref), ">")),
     }
 }

--- a/src/core/generate/rs/src/bindings/typescript_native/new_typescript_native_types.rs
+++ b/src/core/generate/rs/src/bindings/typescript_native/new_typescript_native_types.rs
@@ -1,6 +1,7 @@
 use super::super::javascript::is_tuple;
 use super::comments::add_comments;
 use super::conversion_functions_generator::{TopLevelNodes, TypeConverter};
+use super::original_typescript_types::create_typed_array_type;
 use super::utils::{get_ident_guarded, get_ident_guarded_keyword_ok};
 use candid::types::{Field, Function, Label, Type, TypeEnv, TypeInner};
 use candid_parser::syntax::{self, IDLMergedProg, IDLType};
@@ -367,14 +368,14 @@ fn create_vector_type(
     };
 
     match ty.as_ref() {
-        Nat8 => create_union_array_type("Uint8Array", "number"),
-        Nat16 => create_union_array_type("Uint16Array", "number"),
-        Nat32 => create_union_array_type("Uint32Array", "number"),
-        Nat64 => create_union_array_type("BigUint64Array", "bigint"),
-        Int8 => create_union_array_type("Int8Array", "number"),
-        Int16 => create_union_array_type("Int16Array", "number"),
-        Int32 => create_union_array_type("Int32Array", "number"),
-        Int64 => create_union_array_type("BigInt64Array", "bigint"),
+        Nat8 => create_typed_array_type("Uint8Array"),
+        Nat16 => create_typed_array_type("Uint16Array"),
+        Nat32 => create_typed_array_type("Uint32Array"),
+        Nat64 => create_typed_array_type("BigUint64Array"),
+        Int8 => create_typed_array_type("Int8Array"),
+        Int16 => create_typed_array_type("Int16Array"),
+        Int32 => create_typed_array_type("Int32Array"),
+        Int64 => create_typed_array_type("BigInt64Array"),
         _ => {
             // Generic array type
             TsType::TsTypeRef(TsTypeRef {
@@ -438,37 +439,6 @@ fn create_record_type(
                 .collect(),
         })
     }
-}
-
-// Helper to create union array types like "Uint8Array | number[]"
-fn create_union_array_type(typed_array: &str, elem_type: &str) -> TsType {
-    TsType::TsUnionOrIntersectionType(TsUnionOrIntersectionType::TsUnionType(TsUnionType {
-        span: DUMMY_SP,
-        types: vec![
-            // TypedArray (e.g., Uint8Array)
-            Box::new(TsType::TsTypeRef(TsTypeRef {
-                span: DUMMY_SP,
-                type_name: TsEntityName::Ident(Ident::new(
-                    typed_array.into(),
-                    DUMMY_SP,
-                    SyntaxContext::empty(),
-                )),
-                type_params: None,
-            })),
-            // Regular array (e.g., number[])
-            Box::new(TsType::TsArrayType(TsArrayType {
-                span: DUMMY_SP,
-                elem_type: Box::new(TsType::TsKeywordType(TsKeywordType {
-                    span: DUMMY_SP,
-                    kind: match elem_type {
-                        "number" => TsKeywordTypeKind::TsNumberKeyword,
-                        "bigint" => TsKeywordTypeKind::TsBigIntKeyword,
-                        _ => TsKeywordTypeKind::TsAnyKeyword,
-                    },
-                })),
-            })),
-        ],
-    }))
 }
 
 fn create_variant_type(

--- a/src/core/generate/rs/src/bindings/typescript_native/original_typescript_types.rs
+++ b/src/core/generate/rs/src/bindings/typescript_native/original_typescript_types.rs
@@ -242,14 +242,14 @@ impl<'a> OriginalTypescriptTypes<'a> {
                 };
 
                 match ty.as_ref() {
-                    TypeInner::Nat8 => self.create_union_array_type("Uint8Array", "number"),
-                    TypeInner::Nat16 => self.create_union_array_type("Uint16Array", "number"),
-                    TypeInner::Nat32 => self.create_union_array_type("Uint32Array", "number"),
-                    TypeInner::Nat64 => self.create_union_array_type("BigUint64Array", "bigint"),
-                    TypeInner::Int8 => self.create_union_array_type("Int8Array", "number"),
-                    TypeInner::Int16 => self.create_union_array_type("Int16Array", "number"),
-                    TypeInner::Int32 => self.create_union_array_type("Int32Array", "number"),
-                    TypeInner::Int64 => self.create_union_array_type("BigInt64Array", "bigint"),
+                    TypeInner::Nat8 => create_typed_array_type("Uint8Array"),
+                    TypeInner::Nat16 => create_typed_array_type("Uint16Array"),
+                    TypeInner::Nat32 => create_typed_array_type("Uint32Array"),
+                    TypeInner::Nat64 => create_typed_array_type("BigUint64Array"),
+                    TypeInner::Int8 => create_typed_array_type("Int8Array"),
+                    TypeInner::Int16 => create_typed_array_type("Int16Array"),
+                    TypeInner::Int32 => create_typed_array_type("Int32Array"),
+                    TypeInner::Int64 => create_typed_array_type("BigInt64Array"),
                     _ => {
                         // Generic array type
                         TsType::TsTypeRef(TsTypeRef {
@@ -346,36 +346,6 @@ impl<'a> OriginalTypescriptTypes<'a> {
             })
             .collect(),
         })
-    }
-
-    fn create_union_array_type(&mut self, typed_array: &str, elem_type: &str) -> TsType {
-        TsType::TsUnionOrIntersectionType(TsUnionOrIntersectionType::TsUnionType(TsUnionType {
-            span: DUMMY_SP,
-            types: vec![
-                // TypedArray (e.g., Uint8Array)
-                Box::new(TsType::TsTypeRef(TsTypeRef {
-                    span: DUMMY_SP,
-                    type_name: TsEntityName::Ident(Ident::new(
-                        typed_array.into(),
-                        DUMMY_SP,
-                        SyntaxContext::empty(),
-                    )),
-                    type_params: None,
-                })),
-                // Regular array (e.g., number[])
-                Box::new(TsType::TsArrayType(TsArrayType {
-                    span: DUMMY_SP,
-                    elem_type: Box::new(TsType::TsKeywordType(TsKeywordType {
-                        span: DUMMY_SP,
-                        kind: match elem_type {
-                            "number" => TsKeywordTypeKind::TsNumberKeyword,
-                            "bigint" => TsKeywordTypeKind::TsBigIntKeyword,
-                            _ => TsKeywordTypeKind::TsAnyKeyword,
-                        },
-                    })),
-                })),
-            ],
-        }))
     }
 
     fn create_property_signature(&mut self, field: &Field) -> TsTypeElement {
@@ -488,4 +458,17 @@ impl<'a> OriginalTypescriptTypes<'a> {
                 phase: Default::default(),
             })));
     }
+}
+
+/// Create typed array types like "Uint8Array"
+pub fn create_typed_array_type(typed_array: &str) -> TsType {
+    TsType::TsTypeRef(TsTypeRef {
+        span: DUMMY_SP,
+        type_name: TsEntityName::Ident(Ident::new(
+            typed_array.into(),
+            DUMMY_SP,
+            SyntaxContext::empty(),
+        )),
+        type_params: None,
+    })
 }

--- a/tests/snapshots/generate/example/declarations/example.did.d.ts.snapshot
+++ b/tests/snapshots/generate/example/declarations/example.did.d.ts.snapshot
@@ -161,7 +161,7 @@ export interface _SERVICE {
   /**
    * Doc comment for f1 method of service
    */
-  'f1' : ActorMethod<[list, Uint8Array | number[], [] | [boolean]], undefined>,
+  'f1' : ActorMethod<[list, Uint8Array, [] | [boolean]], undefined>,
   'g1' : ActorMethod<
     [my_type, nested_opt, List, [] | [List], nested],
     [bigint, Principal, nested_res]

--- a/tests/snapshots/generate/example/example.d.ts.snapshot
+++ b/tests/snapshots/generate/example/example.d.ts.snapshot
@@ -176,7 +176,7 @@ export interface exampleInterface {
     /**
      * Doc comment for f1 method of service
      */
-    f1(arg0: list, test: Uint8Array | number[], arg2: boolean | null): Promise<void>;
+    f1(arg0: list, test: Uint8Array, arg2: boolean | null): Promise<void>;
     g1(arg0: my_type, arg1: nested_opt, arg2: List, arg3: List | null, arg4: nested): Promise<[bigint, Principal, nested_res]>;
     h(arg0: Array<string | null>, arg1: {
         __kind__: "A";

--- a/tests/snapshots/generate/example/example.ts.snapshot
+++ b/tests/snapshots/generate/example/example.ts.snapshot
@@ -210,7 +210,7 @@ export interface exampleInterface {
     /**
      * Doc comment for f1 method of service
      */
-    f1(arg0: list, test: Uint8Array | number[], arg2: boolean | null): Promise<void>;
+    f1(arg0: list, test: Uint8Array, arg2: boolean | null): Promise<void>;
     g1(arg0: my_type, arg1: nested_opt, arg2: List, arg3: List | null, arg4: nested): Promise<[bigint, Principal, nested_res]>;
     h(arg0: Array<string | null>, arg1: {
         __kind__: "A";
@@ -247,7 +247,7 @@ export interface exampleInterface {
 import type { A as _A, B as _B, List as _List, a as _a, b as _b, list as _list, my_variant as _my_variant, nested as _nested, nested_opt as _nested_opt, nested_records as _nested_records, nested_res as _nested_res, node as _node, res as _res, stream as _stream, tree as _tree } from "./declarations/example.did.d.ts";
 export class Example implements exampleInterface {
     constructor(private actor: ActorSubclass<_SERVICE>){}
-    async f1(arg0: list, arg1: Uint8Array | number[], arg2: boolean | null): Promise<void> {
+    async f1(arg0: list, arg1: Uint8Array, arg2: boolean | null): Promise<void> {
         const result = await this.actor.f1(to_candid_list_n1(arg0), arg1, to_candid_opt_n5(arg2));
         return result;
     }

--- a/tests/snapshots/wasm-generate/example/declarations/example.did.d.ts.snapshot
+++ b/tests/snapshots/wasm-generate/example/declarations/example.did.d.ts.snapshot
@@ -153,7 +153,7 @@ export interface _SERVICE {
   /**
    * Doc comment for f1 method of service
    */
-  'f1' : ActorMethod<[list, Uint8Array | number[], [] | [boolean]], undefined>,
+  'f1' : ActorMethod<[list, Uint8Array, [] | [boolean]], undefined>,
   'g1' : ActorMethod<
     [my_type, nested_opt, List, [] | [List], nested],
     [bigint, Principal, nested_res]

--- a/tests/snapshots/wasm-generate/example/example.d.ts.snapshot
+++ b/tests/snapshots/wasm-generate/example/example.d.ts.snapshot
@@ -168,7 +168,7 @@ export interface exampleInterface {
     /**
      * Doc comment for f1 method of service
      */
-    f1(arg0: list, test: Uint8Array | number[], arg2: boolean | null): Promise<void>;
+    f1(arg0: list, test: Uint8Array, arg2: boolean | null): Promise<void>;
     g1(arg0: my_type, arg1: nested_opt, arg2: List, arg3: List | null, arg4: nested): Promise<[bigint, Principal, nested_res]>;
     h(arg0: Array<string | null>, arg1: {
         __kind__: "A";

--- a/tests/snapshots/wasm-generate/example/example.ts.snapshot
+++ b/tests/snapshots/wasm-generate/example/example.ts.snapshot
@@ -202,7 +202,7 @@ export interface exampleInterface {
     /**
      * Doc comment for f1 method of service
      */
-    f1(arg0: list, test: Uint8Array | number[], arg2: boolean | null): Promise<void>;
+    f1(arg0: list, test: Uint8Array, arg2: boolean | null): Promise<void>;
     g1(arg0: my_type, arg1: nested_opt, arg2: List, arg3: List | null, arg4: nested): Promise<[bigint, Principal, nested_res]>;
     h(arg0: Array<string | null>, arg1: {
         __kind__: "A";
@@ -239,7 +239,7 @@ export interface exampleInterface {
 import type { A as _A, B as _B, List as _List, a as _a, b as _b, list as _list, my_variant as _my_variant, nested as _nested, nested_opt as _nested_opt, nested_records as _nested_records, nested_res as _nested_res, node as _node, res as _res, stream as _stream, tree as _tree } from "./declarations/example.did.d.ts";
 export class Example implements exampleInterface {
     constructor(private actor: ActorSubclass<_SERVICE>){}
-    async f1(arg0: list, arg1: Uint8Array | number[], arg2: boolean | null): Promise<void> {
+    async f1(arg0: list, arg1: Uint8Array, arg2: boolean | null): Promise<void> {
         const result = await this.actor.f1(to_candid_list_n1(arg0), arg1, to_candid_opt_n5(arg2));
         return result;
     }


### PR DESCRIPTION
For typed arrays, the Candid JS implementation already returns the corresponding typed array, see https://github.com/dfinity/icp-js-core/blob/93cea11942ffda7e33227525699a94da9145b627/packages/candid/src/idl.ts#L1003-L1074.
