### PR TITLE
fix: parse and ignore the named return arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "candid"
 version = "0.10.19"
-source = "git+https://github.com/dfinity/candid?branch=next#b751d391b785d4f0735624cf38213ecaea16abee"
+source = "git+https://github.com/dfinity/candid?branch=next#77731176bed02159c0aeee8c5cfe95ca1d051749"
 dependencies = [
  "anyhow",
  "binread",
@@ -242,7 +242,7 @@ dependencies = [
 [[package]]
 name = "candid_derive"
 version = "0.10.19"
-source = "git+https://github.com/dfinity/candid?branch=next#b751d391b785d4f0735624cf38213ecaea16abee"
+source = "git+https://github.com/dfinity/candid?branch=next#77731176bed02159c0aeee8c5cfe95ca1d051749"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -253,7 +253,7 @@ dependencies = [
 [[package]]
 name = "candid_parser"
 version = "0.2.2"
-source = "git+https://github.com/dfinity/candid?branch=next#b751d391b785d4f0735624cf38213ecaea16abee"
+source = "git+https://github.com/dfinity/candid?branch=next#77731176bed02159c0aeee8c5cfe95ca1d051749"
 dependencies = [
  "anyhow",
  "candid",
@@ -687,7 +687,7 @@ dependencies = [
 [[package]]
 name = "ic_principal"
 version = "0.1.1"
-source = "git+https://github.com/dfinity/candid?branch=next#b751d391b785d4f0735624cf38213ecaea16abee"
+source = "git+https://github.com/dfinity/candid?branch=next#77731176bed02159c0aeee8c5cfe95ca1d051749"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/src/core/generate/rs/src/bindings/javascript.rs
+++ b/src/core/generate/rs/src/bindings/javascript.rs
@@ -163,18 +163,20 @@ fn pp_fields(fs: &[Field]) -> RcDoc<'_> {
 
 fn pp_function(func: &Function) -> RcDoc<'_> {
     let args = pp_args(&func.args);
-    let rets = pp_rets(&func.rets);
+    let rets = pp_args(&func.rets);
     let modes = pp_modes(&func.modes);
     sep_enclose([args, rets, modes], ",", "(", ")").nest(INDENT_SPACE)
 }
 
 fn pp_args(args: &[ArgType]) -> RcDoc<'_> {
-    let args = args.iter().map(|arg| pp_ty(&arg.typ));
-    sep_enclose(args, ",", "[", "]")
+    pp_types(args.iter().map(|arg| &arg.typ))
 }
 
-fn pp_rets(args: &[Type]) -> RcDoc<'_> {
-    sep_enclose(args.iter().map(pp_ty), ",", "[", "]")
+fn pp_types<'a, T>(types: T) -> RcDoc<'a>
+where
+    T: Iterator<Item = &'a Type>,
+{
+    sep_enclose(types.map(pp_ty), ",", "[", "]")
 }
 
 fn pp_modes(modes: &[candid::types::FuncMode]) -> RcDoc<'_> {
@@ -276,7 +278,7 @@ pub fn compile(env: &TypeEnv, actor: &Option<Type>) -> String {
                 .append(";");
 
             let idl_init_args = str("export const idlInitArgs = ")
-                .append(pp_rets(init_types))
+                .append(pp_types(init_types.iter()))
                 .append(";");
 
             let idl_factory_return = kwd("return").append(actor).append(";");
@@ -287,7 +289,9 @@ pub fn compile(env: &TypeEnv, actor: &Option<Type>) -> String {
             let init_defs = chase_types(env, init_types).unwrap();
             let init_recs = infer_rec(env, &init_defs).unwrap();
             let init_defs_doc = pp_defs(env, &init_defs, &init_recs, false);
-            let init_doc = kwd("return").append(pp_rets(init_types)).append(";");
+            let init_doc = kwd("return")
+                .append(pp_types(init_types.iter()))
+                .append(";");
             let init_doc = init_defs_doc.append(init_doc);
             let init_doc =
                 str("export const init = ({ IDL }) => ").append(enclose_space("{", init_doc, "};"));

--- a/src/core/generate/rs/src/bindings/typescript.rs
+++ b/src/core/generate/rs/src/bindings/typescript.rs
@@ -209,9 +209,9 @@ fn pp_function<'a>(env: &'a TypeEnv, func: &'a Function) -> RcDoc<'a> {
     let args = sep_enclose(args, ",", "[", "]");
     let rets = match func.rets.len() {
         0 => str("undefined"),
-        1 => pp_ty(env, &func.rets[0], true),
+        1 => pp_ty(env, &func.rets[0].typ, true),
         _ => sep_enclose(
-            func.rets.iter().map(|ty| pp_ty(env, ty, true)),
+            func.rets.iter().map(|ret| pp_ty(env, &ret.typ, true)),
             ",",
             "[",
             "]",

--- a/src/core/generate/rs/src/bindings/typescript_native/compile_wrapper.rs
+++ b/src/core/generate/rs/src/bindings/typescript_native/compile_wrapper.rs
@@ -354,7 +354,7 @@ fn create_actor_method(
             span: DUMMY_SP,
             kind: TsKeywordTypeKind::TsVoidKeyword,
         }),
-        1 => convert_type_with_converter(converter, env, &func.rets[0], None, true),
+        1 => convert_type_with_converter(converter, env, &func.rets[0].typ, None, true),
         _ => {
             // Create a tuple type for multiple return values
             TsType::TsTupleType(TsTupleType {
@@ -362,10 +362,12 @@ fn create_actor_method(
                 elem_types: func
                     .rets
                     .iter()
-                    .map(|ty| TsTupleElement {
+                    .map(|ret| TsTupleElement {
                         span: DUMMY_SP,
                         label: None,
-                        ty: Box::new(convert_type_with_converter(converter, env, ty, None, true)),
+                        ty: Box::new(convert_type_with_converter(
+                            converter, env, &ret.typ, None, true,
+                        )),
                     })
                     .collect(),
             })

--- a/src/core/generate/rs/src/bindings/typescript_native/new_typescript_native_types.rs
+++ b/src/core/generate/rs/src/bindings/typescript_native/new_typescript_native_types.rs
@@ -928,7 +928,7 @@ fn create_method_signature(
             span: DUMMY_SP,
             kind: TsKeywordTypeKind::TsVoidKeyword,
         }),
-        1 => convert_type(top_level_nodes, env, &func.rets[0], None, true),
+        1 => convert_type(top_level_nodes, env, &func.rets[0].typ, None, true),
         _ => {
             // Create a tuple type for multiple return values
             TsType::TsTupleType(TsTupleType {
@@ -936,10 +936,10 @@ fn create_method_signature(
                 elem_types: func
                     .rets
                     .iter()
-                    .map(|ty| TsTupleElement {
+                    .map(|ret| TsTupleElement {
                         span: DUMMY_SP,
                         label: None,
-                        ty: Box::new(convert_type(top_level_nodes, env, ty, None, true)),
+                        ty: Box::new(convert_type(top_level_nodes, env, &ret.typ, None, true)),
                     })
                     .collect(),
             })
@@ -1003,7 +1003,7 @@ fn create_function_type(
             span: DUMMY_SP,
             kind: TsKeywordTypeKind::TsVoidKeyword,
         }),
-        1 => convert_type(top_level_nodes, env, &func.rets[0], None, true),
+        1 => convert_type(top_level_nodes, env, &func.rets[0].typ, None, true),
         _ => {
             // Create a tuple type for multiple return values
             TsType::TsTupleType(TsTupleType {
@@ -1011,10 +1011,10 @@ fn create_function_type(
                 elem_types: func
                     .rets
                     .iter()
-                    .map(|ty| TsTupleElement {
+                    .map(|ret| TsTupleElement {
                         span: DUMMY_SP,
                         label: None,
-                        ty: Box::new(convert_type(top_level_nodes, env, ty, None, true)),
+                        ty: Box::new(convert_type(top_level_nodes, env, &ret.typ, None, true)),
                     })
                     .collect(),
             })

--- a/src/core/generate/rs/src/parser.rs
+++ b/src/core/generate/rs/src/parser.rs
@@ -74,8 +74,8 @@ pub fn check_type(env: &Env, t: &IDLType) -> Result<Type> {
                 t1.push(check_arg(env, arg)?);
             }
             let mut t2 = Vec::new();
-            for t in func.rets.iter() {
-                t2.push(check_type(env, t)?);
+            for ret in func.rets.iter() {
+                t2.push(check_arg(env, ret)?);
             }
             if func.modes.len() > 1 {
                 return Err(Error::msg("cannot have more than one mode"));

--- a/tests/assets/example.did
+++ b/tests/assets/example.did
@@ -83,7 +83,7 @@ type my_variant = variant {
 service server : {
   // Doc comment for f1 method of service
   f1 : (list, test: blob, opt bool) -> () oneway;
-  g1 : (my_type, nested_opt, List, opt List, nested) -> (int, broker, nested_res) query;
+  g1 : (my_type, nested_opt, List, opt List, nested) -> (ret0 : int, broker, ret2 : nested_res) query;
   h : (vec opt text, variant { A: nat; B: opt text }, opt List) -> (
     record {
       // Doc comment for id field in h method return, currently ignored


### PR DESCRIPTION
Follow-up of https://github.com/dfinity/candid/pull/684.
