### PR TITLE
refactor: accept object as input for wasm generate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "handlebars"
 version = "6.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,7 +719,10 @@ dependencies = [
  "console_error_panic_hook",
  "log",
  "pretty",
+ "serde",
+ "serde-wasm-bindgen",
  "swc_core",
+ "tsify",
  "wasm-bindgen",
  "wasm-bindgen-console-logger",
 ]
@@ -1416,6 +1432,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,6 +1466,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2025,6 +2063,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tsify"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec5505497c87f1c050b4392d3f11b49a04537fcb9dc0da57bc0af168a6331f2"
+dependencies = [
+ "gloo-utils",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "tsify-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tsify-macros"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc2c44dc9fe4baf55b88e032621b7a11b215a1f0a7de8d0aa04367207d915bc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,6 +2290,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/src/core/generate/index.ts
+++ b/src/core/generate/index.ts
@@ -99,7 +99,10 @@ export async function generate(options: GenerateOptions) {
   await ensureDir(outDir);
   await ensureDir(resolve(outDir, 'declarations'));
 
-  const result = wasmGenerate(didFilePath, outputFileName);
+  const result = wasmGenerate({
+    did_file_path: didFilePath,
+    service_name: outputFileName,
+  });
 
   await writeBindings({
     bindings: result,

--- a/src/core/generate/rs.ts
+++ b/src/core/generate/rs.ts
@@ -1,4 +1,4 @@
-import type { GenerateResult } from './rs/dist/icp-js-bindgen.d.ts';
+import type { GenerateOptions, GenerateResult } from './rs/dist/icp-js-bindgen.d.ts';
 import init, { generate, start } from './rs/dist/icp-js-bindgen.js';
 
 let initialized = false;
@@ -14,4 +14,5 @@ export async function wasmInit(...args: Parameters<typeof init>) {
 
 export const wasmStart = start;
 export const wasmGenerate = generate;
+export type WasmGenerateOptions = GenerateOptions;
 export type WasmGenerateResult = GenerateResult;

--- a/src/core/generate/rs/Cargo.toml
+++ b/src/core/generate/rs/Cargo.toml
@@ -24,4 +24,7 @@ console_error_panic_hook = "0.1"
 wasm-bindgen-console-logger = "0.1"
 log = "0.4"
 pretty = "0.12"
+serde = { version = "1.0", features = ["derive"] }
+serde-wasm-bindgen = "0.6"
+tsify = { version = "0.5", features = ["js"] }
 swc_core = { version = "44.0.0", features = ["common", "ecma_ast", "ecma_codegen"] }

--- a/tests/wasm-generate.test.ts
+++ b/tests/wasm-generate.test.ts
@@ -13,7 +13,10 @@ describe('wasmGenerate', () => {
   it.each(['hello_world', 'example'])('should generate a bindgen', async (serviceName) => {
     const didFile = `${TESTS_ASSETS_DIR}/${serviceName}.did`;
 
-    const result = wasmGenerate(didFile, serviceName);
+    const result = wasmGenerate({
+      did_file_path: didFile,
+      service_name: serviceName,
+    });
     await expect(result.declarations_js).toMatchFileSnapshot(
       `${SNAPSHOTS_DIR}/${serviceName}/declarations/${serviceName}.did.js.snapshot`,
     );


### PR DESCRIPTION
Switch to object as input for stronger typing. Helps for adding more arguments in the future.
