### PR TITLE
chore(deps): replace candid `next` branch with published candid 0.10.30 / candid_parser 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,8 @@ dependencies = [
 [[package]]
 name = "candid"
 version = "0.10.30"
-source = "git+https://github.com/dfinity/candid?branch=js-bindgen-named-args-parser#39ad3476ce07121ff2b515304e7f4e8943538ae3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc4495aa7a596cad1570886668cd3cdb1f077ec2ad28e7e3938a76756c89d80"
 dependencies = [
  "anyhow",
  "binread",
@@ -240,7 +241,8 @@ dependencies = [
 [[package]]
 name = "candid_derive"
 version = "0.10.30"
-source = "git+https://github.com/dfinity/candid?branch=js-bindgen-named-args-parser#39ad3476ce07121ff2b515304e7f4e8943538ae3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c93f446781aa35d3b2ec5c36e3d67fce948308fe166833ccbb1b3ef8bbb899e0"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -251,7 +253,8 @@ dependencies = [
 [[package]]
 name = "candid_parser"
 version = "0.4.0"
-source = "git+https://github.com/dfinity/candid?branch=js-bindgen-named-args-parser#39ad3476ce07121ff2b515304e7f4e8943538ae3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e35c12ed409a6c02c6e204db49926c75ceeb622a4a994b828cdd3dea7dfec59"
 dependencies = [
  "anyhow",
  "candid",
@@ -681,7 +684,8 @@ dependencies = [
 [[package]]
 name = "ic_principal"
 version = "0.1.3"
-source = "git+https://github.com/dfinity/candid?branch=js-bindgen-named-args-parser#39ad3476ce07121ff2b515304e7f4e8943538ae3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aea751965eaf92990be8c79c64b4f3174ff22dd3604e6696a06a494afbaba2a"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "candid"
 version = "0.10.30"
-source = "git+https://github.com/dfinity/candid?branch=js-bindgen-named-args-parser#31473d2250537e2ae0c315116e2d2735d98517ca"
+source = "git+https://github.com/dfinity/candid?branch=js-bindgen-named-args-parser#39ad3476ce07121ff2b515304e7f4e8943538ae3"
 dependencies = [
  "anyhow",
  "binread",
@@ -240,7 +240,7 @@ dependencies = [
 [[package]]
 name = "candid_derive"
 version = "0.10.30"
-source = "git+https://github.com/dfinity/candid?branch=js-bindgen-named-args-parser#31473d2250537e2ae0c315116e2d2735d98517ca"
+source = "git+https://github.com/dfinity/candid?branch=js-bindgen-named-args-parser#39ad3476ce07121ff2b515304e7f4e8943538ae3"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "candid_parser"
 version = "0.4.0"
-source = "git+https://github.com/dfinity/candid?branch=js-bindgen-named-args-parser#31473d2250537e2ae0c315116e2d2735d98517ca"
+source = "git+https://github.com/dfinity/candid?branch=js-bindgen-named-args-parser#39ad3476ce07121ff2b515304e7f4e8943538ae3"
 dependencies = [
  "anyhow",
  "candid",
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "ic_principal"
 version = "0.1.3"
-source = "git+https://github.com/dfinity/candid?branch=js-bindgen-named-args-parser#31473d2250537e2ae0c315116e2d2735d98517ca"
+source = "git+https://github.com/dfinity/candid?branch=js-bindgen-named-args-parser#39ad3476ce07121ff2b515304e7f4e8943538ae3"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,15 +217,13 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.19"
-source = "git+https://github.com/dfinity/candid?branch=next#77731176bed02159c0aeee8c5cfe95ca1d051749"
+version = "0.10.30"
+source = "git+https://github.com/dfinity/candid?branch=js-bindgen-named-args-parser#31473d2250537e2ae0c315116e2d2735d98517ca"
 dependencies = [
  "anyhow",
  "binread",
  "byteorder",
  "candid_derive",
- "foldhash",
- "hashbrown 0.15.5",
  "hex",
  "ic_principal",
  "leb128",
@@ -241,8 +239,8 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.19"
-source = "git+https://github.com/dfinity/candid?branch=next#77731176bed02159c0aeee8c5cfe95ca1d051749"
+version = "0.10.30"
+source = "git+https://github.com/dfinity/candid?branch=js-bindgen-named-args-parser#31473d2250537e2ae0c315116e2d2735d98517ca"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -252,8 +250,8 @@ dependencies = [
 
 [[package]]
 name = "candid_parser"
-version = "0.2.2"
-source = "git+https://github.com/dfinity/candid?branch=next#77731176bed02159c0aeee8c5cfe95ca1d051749"
+version = "0.4.0"
+source = "git+https://github.com/dfinity/candid?branch=js-bindgen-named-args-parser#31473d2250537e2ae0c315116e2d2735d98517ca"
 dependencies = [
  "anyhow",
  "candid",
@@ -559,12 +557,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,17 +643,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
@@ -699,8 +680,8 @@ dependencies = [
 
 [[package]]
 name = "ic_principal"
-version = "0.1.1"
-source = "git+https://github.com/dfinity/candid?branch=next#77731176bed02159c0aeee8c5cfe95ca1d051749"
+version = "0.1.3"
+source = "git+https://github.com/dfinity/candid?branch=js-bindgen-named-args-parser#31473d2250537e2ae0c315116e2d2735d98517ca"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/src/core/generate/rs/Cargo.toml
+++ b/src/core/generate/rs/Cargo.toml
@@ -16,8 +16,13 @@ crate-type = ["cdylib"]
 wasm-opt = ["-Oz", "--enable-mutable-globals"]
 
 [dependencies]
-candid = { git = "https://github.com/dfinity/candid", branch = "next" }
-candid_parser = { git = "https://github.com/dfinity/candid", branch = "next" }
+# Temporarily track the candid PR branch (named-args parser support) so CI can
+# verify both projects work together. Both deps come from the same candid repo
+# checkout, so candid_parser's internal `candid` path dep unifies with this
+# `candid`. Switch to the published `candid` 0.10 / `candid_parser` 0.4 releases
+# once the candid PR (dfinity/candid#742) is merged and released.
+candid = { git = "https://github.com/dfinity/candid", branch = "js-bindgen-named-args-parser" }
+candid_parser = { git = "https://github.com/dfinity/candid", branch = "js-bindgen-named-args-parser" }
 
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1"

--- a/src/core/generate/rs/Cargo.toml
+++ b/src/core/generate/rs/Cargo.toml
@@ -16,13 +16,8 @@ crate-type = ["cdylib"]
 wasm-opt = ["-Oz", "--enable-mutable-globals"]
 
 [dependencies]
-# Temporarily track the candid PR branch (named-args parser support) so CI can
-# verify both projects work together. Both deps come from the same candid repo
-# checkout, so candid_parser's internal `candid` path dep unifies with this
-# `candid`. Switch to the published `candid` 0.10 / `candid_parser` 0.4 releases
-# once the candid PR (dfinity/candid#742) is merged and released.
-candid = { git = "https://github.com/dfinity/candid", branch = "js-bindgen-named-args-parser" }
-candid_parser = { git = "https://github.com/dfinity/candid", branch = "js-bindgen-named-args-parser" }
+candid = "0.10.30"
+candid_parser = "0.4.0"
 
 wasm-bindgen = "0.2"
 console_error_panic_hook = "0.1"

--- a/src/core/generate/rs/src/bindings/javascript.rs
+++ b/src/core/generate/rs/src/bindings/javascript.rs
@@ -2,7 +2,7 @@
 
 use candid::pretty::candid::pp_mode;
 use candid::pretty::utils::*;
-use candid::types::{ArgType, Field, Function, Label, SharedLabel, Type, TypeEnv, TypeInner};
+use candid::types::{Field, Function, Label, SharedLabel, Type, TypeEnv, TypeInner};
 use candid_parser::bindings::analysis::{chase_actor, chase_types, infer_rec};
 use candid_parser::syntax::IDLMergedProg;
 use pretty::RcDoc;
@@ -169,8 +169,8 @@ fn pp_function(func: &Function) -> RcDoc<'_> {
     sep_enclose([args, rets, modes], ",", "(", ")").nest(INDENT_SPACE)
 }
 
-fn pp_args(args: &[ArgType]) -> RcDoc<'_> {
-    pp_types(args.iter().map(|arg| &arg.typ))
+fn pp_args(args: &[Type]) -> RcDoc<'_> {
+    pp_types(args.iter())
 }
 
 fn pp_types<'a, T>(types: T) -> RcDoc<'a>
@@ -197,12 +197,12 @@ fn references_var(ty: &Type, name: &str) -> bool {
             fields.iter().any(|f| references_var(&f.ty, name))
         }
         TypeInner::Func(func) => {
-            func.args.iter().any(|a| references_var(&a.typ, name))
-                || func.rets.iter().any(|r| references_var(&r.typ, name))
+            func.args.iter().any(|a| references_var(a, name))
+                || func.rets.iter().any(|r| references_var(r, name))
         }
         TypeInner::Service(methods) => methods.iter().any(|(_, m)| references_var(m, name)),
         TypeInner::Class(args, ty) => {
-            args.iter().any(|a| references_var(&a.typ, name)) || references_var(ty, name)
+            args.iter().any(|a| references_var(a, name)) || references_var(ty, name)
         }
         _ => false,
     }
@@ -221,7 +221,7 @@ fn find_service_in_cycle<'a>(
         if recs.contains(s_id) {
             continue;
         }
-        let Ok(s_ty) = env.find_type(&s_id.into()) else {
+        let Ok(s_ty) = env.find_type(s_id) else {
             continue;
         };
         let TypeInner::Service(methods) = s_ty.as_ref() else {
@@ -233,8 +233,8 @@ fn find_service_in_cycle<'a>(
             continue;
         }
 
-        let references_service = func.args.iter().any(|arg| references_var(&arg.typ, s_id))
-            || func.rets.iter().any(|ret| references_var(&ret.typ, s_id));
+        let references_service = func.args.iter().any(|arg| references_var(arg, s_id))
+            || func.rets.iter().any(|ret| references_var(ret, s_id));
 
         if references_service {
             return Some(s_id);
@@ -267,7 +267,7 @@ fn optimize_recs<'a>(
     let swaps: Vec<(String, String)> = initial_recs
         .iter()
         .filter_map(|func_id| {
-            let ty = env.find_type(&func_id.as_str().into()).ok()?;
+            let ty = env.find_type(func_id.as_str()).ok()?;
             let TypeInner::Func(func) = ty.as_ref() else {
                 return None;
             };
@@ -320,7 +320,7 @@ fn pp_defs<'a>(
             .append(" = IDL.Rec();")
     }));
     let mut defs = lines(def_list.iter().map(|&id| {
-        let ty = env.find_type(&id.into()).unwrap();
+        let ty = env.find_type(id).unwrap();
         if recs.contains(id) {
             ident(id)
                 .append(".fill")
@@ -383,7 +383,7 @@ pub fn compile(env: &TypeEnv, actor: &Option<Type>, root_exports: bool) -> Strin
             let recs_owned = optimize_recs(env, &mut def_list, initial_recs);
             let recs: BTreeSet<&str> = recs_owned.iter().map(|s| s.as_str()).collect();
             let types = if let TypeInner::Class(args, _) = actor.as_ref() {
-                args.iter().map(|arg| arg.typ.clone()).collect::<Vec<_>>()
+                args.clone()
             } else {
                 Vec::new()
             };
@@ -492,7 +492,7 @@ pub fn compile_typescript(
             let recs_owned = infer_and_optimize_recs(env, &mut def_list);
             let recs: BTreeSet<&str> = recs_owned.iter().map(|s| s.as_str()).collect();
             let types = if let TypeInner::Class(args, _) = actor.as_ref() {
-                args.iter().map(|arg| arg.typ.clone()).collect::<Vec<_>>()
+                args.clone()
             } else {
                 Vec::new()
             };

--- a/src/core/generate/rs/src/bindings/typescript.rs
+++ b/src/core/generate/rs/src/bindings/typescript.rs
@@ -206,13 +206,13 @@ fn pp_opt<'a>(
 }
 
 fn pp_function<'a>(env: &'a TypeEnv, func: &'a Function) -> RcDoc<'a> {
-    let args = func.args.iter().map(|arg| pp_ty(env, &arg.typ, true));
+    let args = func.args.iter().map(|arg| pp_ty(env, arg, true));
     let args = sep_enclose(args, ",", "[", "]");
     let rets = match func.rets.len() {
         0 => str("undefined"),
-        1 => pp_ty(env, &func.rets[0].typ, true),
+        1 => pp_ty(env, &func.rets[0], true),
         _ => sep_enclose(
-            func.rets.iter().map(|ret| pp_ty(env, &ret.typ, true)),
+            func.rets.iter().map(|ret| pp_ty(env, ret, true)),
             ",",
             "[",
             "]",
@@ -268,7 +268,7 @@ pub(crate) fn pp_defs<'a>(
     prog: &'a IDLMergedProg,
 ) -> RcDoc<'a> {
     lines(def_list.iter().map(|&id| {
-        let ty = env.find_type(&id.into()).unwrap();
+        let ty = env.find_type(id).unwrap();
         let syntax = prog.lookup(id);
         let syntax_ty = syntax.map(|s| &s.typ);
         let docs = syntax

--- a/src/core/generate/rs/src/bindings/typescript_native/compile_wrapper.rs
+++ b/src/core/generate/rs/src/bindings/typescript_native/compile_wrapper.rs
@@ -335,11 +335,7 @@ fn create_actor_method(
                     type_ann: Some(Box::new(TsTypeAnn {
                         span: DUMMY_SP,
                         type_ann: Box::new(convert_type_with_converter(
-                            converter,
-                            env,
-                            arg_ty,
-                            None,
-                            true,
+                            converter, env, arg_ty, None, true,
                         )),
                     })),
                 }),
@@ -364,9 +360,7 @@ fn create_actor_method(
                     .map(|ret| TsTupleElement {
                         span: DUMMY_SP,
                         label: None,
-                        ty: Box::new(convert_type_with_converter(
-                            converter, env, ret, None, true,
-                        )),
+                        ty: Box::new(convert_type_with_converter(converter, env, ret, None, true)),
                     })
                     .collect(),
             })

--- a/src/core/generate/rs/src/bindings/typescript_native/compile_wrapper.rs
+++ b/src/core/generate/rs/src/bindings/typescript_native/compile_wrapper.rs
@@ -1,6 +1,5 @@
 use super::conversion_functions_generator::TypeConverter;
 use super::utils::{contains_unicode_characters, get_ident_guarded, get_ident_guarded_keyword_ok};
-use candid::types::internal::TypeKey;
 use candid::types::{Function, Type, TypeEnv, TypeInner};
 use candid_parser::syntax::IDLMergedProg;
 use swc_core::common::{DUMMY_SP, SyntaxContext};
@@ -169,12 +168,12 @@ fn wrapper_actor_service(
 fn wrapper_actor_var(
     env: &TypeEnv,
     module: &mut Module,
-    type_id: &TypeKey,
+    type_id: &str,
     service_name: &str,
     converter: &mut TypeConverter,
     span: Span,
 ) {
-    interface_actor_var(module, type_id.as_str(), service_name, span);
+    interface_actor_var(module, type_id, service_name, span);
     let type_ref = env.find_type(type_id).unwrap();
     let serv = match type_ref.as_ref() {
         TypeInner::Service(serv) => serv,
@@ -338,7 +337,7 @@ fn create_actor_method(
                         type_ann: Box::new(convert_type_with_converter(
                             converter,
                             env,
-                            &arg_ty.typ,
+                            arg_ty,
                             None,
                             true,
                         )),
@@ -354,7 +353,7 @@ fn create_actor_method(
             span: DUMMY_SP,
             kind: TsKeywordTypeKind::TsVoidKeyword,
         }),
-        1 => convert_type_with_converter(converter, env, &func.rets[0].typ, None, true),
+        1 => convert_type_with_converter(converter, env, &func.rets[0], None, true),
         _ => {
             // Create a tuple type for multiple return values
             TsType::TsTupleType(TsTupleType {
@@ -366,7 +365,7 @@ fn create_actor_method(
                         span: DUMMY_SP,
                         label: None,
                         ty: Box::new(convert_type_with_converter(
-                            converter, env, &ret.typ, None, true,
+                            converter, env, ret, None, true,
                         )),
                     })
                     .collect(),
@@ -400,7 +399,7 @@ fn create_actor_method(
             let arg_expr = Expr::Ident(arg_ident);
 
             // Apply type conversion
-            let converted_expr = converter.convert_to_candid(&arg_expr, &arg_ty.typ);
+            let converted_expr = converter.convert_to_candid(&arg_expr, arg_ty);
 
             ExprOrSpread {
                 spread: None,

--- a/src/core/generate/rs/src/bindings/typescript_native/conversion_functions_generator.rs
+++ b/src/core/generate/rs/src/bindings/typescript_native/conversion_functions_generator.rs
@@ -2,7 +2,7 @@ use super::comments::PosCursor;
 use super::new_typescript_native_types::{convert_type_with_converter, is_recursive_optional};
 use super::original_typescript_types::OriginalTypescriptTypes;
 use super::utils::{EnumDeclarations, contains_unicode_characters, get_ident_guarded};
-use candid::types::{ArgType, Field, Label, Type, TypeEnv, TypeInner};
+use candid::types::{Field, Label, Type, TypeEnv, TypeInner};
 use std::collections::{HashMap, HashSet};
 use swc_core::common::{DUMMY_SP, SyntaxContext, comments::SingleThreadedComments};
 use swc_core::ecma::ast::*;
@@ -1703,14 +1703,14 @@ impl<'a> TypeConverter<'a> {
 pub fn convert_multi_return_from_candid(
     converter: &mut TypeConverter,
     expr: &Expr,
-    types: &[ArgType],
+    types: &[Type],
 ) -> Expr {
     if types.is_empty() {
         // No return value, return void
         Expr::Lit(Lit::Null(Null { span: DUMMY_SP }))
     } else if types.len() == 1 {
         // Single return value
-        converter.convert_from_candid(expr, &types[0].typ)
+        converter.convert_from_candid(expr, &types[0])
     } else {
         // Multiple return values in a tuple
         Expr::Array(ArrayLit {
@@ -1734,12 +1734,12 @@ pub fn convert_multi_return_from_candid(
                     });
 
                     // If type doesn't need conversion, use it directly
-                    let value = if !converter.needs_conversion(&ty.typ) {
+                    let value = if !converter.needs_conversion(ty) {
                         elem_expr
                     } else {
                         // Convert the return value using the appropriate function
-                        let function_name = converter.get_from_candid_function_name(&ty.typ);
-                        converter.generate_from_candid_function(&ty.typ, &function_name);
+                        let function_name = converter.get_from_candid_function_name(ty);
+                        converter.generate_from_candid_function(ty, &function_name);
                         Expr::Call(CallExpr {
                             span: DUMMY_SP,
                             callee: Callee::Expr(Box::new(Expr::Ident(Ident::new(

--- a/src/core/generate/rs/src/bindings/typescript_native/new_typescript_native_types.rs
+++ b/src/core/generate/rs/src/bindings/typescript_native/new_typescript_native_types.rs
@@ -609,7 +609,7 @@ pub fn add_type_definitions(
                 module
                     .body
                     .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                        span: DUMMY_SP,
+                        span,
                         decl: Decl::TsInterface(Box::new(interface)),
                     })));
             }
@@ -625,7 +625,7 @@ pub fn add_type_definitions(
                 module
                     .body
                     .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                        span: DUMMY_SP,
+                        span,
                         decl: Decl::TsInterface(Box::new(interface)),
                     })));
             }
@@ -641,7 +641,7 @@ pub fn add_type_definitions(
                 module
                     .body
                     .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                        span: DUMMY_SP,
+                        span,
                         decl: Decl::TsTypeAlias(Box::new(type_alias)),
                     })));
             }
@@ -667,7 +667,7 @@ pub fn add_type_definitions(
                     module
                         .body
                         .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                            span: DUMMY_SP,
+                            span,
                             decl: Decl::TsTypeAlias(Box::new(type_alias)),
                         })));
                 }

--- a/src/core/generate/rs/src/bindings/typescript_native/new_typescript_native_types.rs
+++ b/src/core/generate/rs/src/bindings/typescript_native/new_typescript_native_types.rs
@@ -59,15 +59,21 @@ pub fn create_interface_from_service(
     let members = serv
         .iter()
         .map(|(method_id, method_ty)| {
-            let span = syntax_serv
-                .and_then(|bindings| bindings.iter().find(|b| &b.id == method_id))
+            let binding =
+                syntax_serv.and_then(|bindings| bindings.iter().find(|b| &b.id == method_id));
+            let span = binding
                 .map(|b| add_comments(top_level_nodes, b.docs.as_ref()))
                 .unwrap_or(DUMMY_SP);
 
             match method_ty.as_ref() {
-                TypeInner::Func(func) => {
-                    create_method_signature(top_level_nodes, env, method_id, func, span)
-                }
+                TypeInner::Func(func) => create_method_signature(
+                    top_level_nodes,
+                    env,
+                    method_id,
+                    func,
+                    binding.map(|b| &b.typ),
+                    span,
+                ),
                 TypeInner::Var(var_id) => TsTypeElement::TsPropertySignature(TsPropertySignature {
                     span,
                     key: Box::new(Expr::Ident(get_ident_guarded(method_id))),
@@ -628,8 +634,13 @@ pub fn add_type_definitions(
                 }
                 TypeInner::Func(func) => {
                     // Generate type alias for function types
-                    let type_alias =
-                        create_type_alias_from_function(top_level_nodes, env, id.as_str(), func);
+                    let type_alias = create_type_alias_from_function(
+                        top_level_nodes,
+                        env,
+                        id.as_str(),
+                        func,
+                        syntax_ty,
+                    );
                     module
                         .body
                         .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
@@ -770,13 +781,14 @@ fn create_type_alias_from_function(
     env: &TypeEnv,
     id: &str,
     func: &Function,
+    syntax: Option<&IDLType>,
 ) -> TsTypeAliasDecl {
     TsTypeAliasDecl {
         span: DUMMY_SP,
         declare: false,
         id: get_ident_guarded(id),
         type_params: None,
-        type_ann: Box::new(create_function_type(top_level_nodes, env, func)),
+        type_ann: Box::new(create_function_type(top_level_nodes, env, func, syntax)),
     }
 }
 
@@ -897,26 +909,41 @@ fn create_property_signature_for_variant(
     })
 }
 
+/// Recover per-argument names from a function's syntax node. Candid's checked
+/// `Function` type (candid 0.10) does not carry argument names, so we read them
+/// from the syntax AST (`IDLArgType.name`); missing names fall back to `arg{i}`.
+fn func_arg_names(syntax: Option<&IDLType>) -> Vec<Option<String>> {
+    match syntax {
+        Some(IDLType::FuncT(f)) => f.args.iter().map(|a| a.name.clone()).collect(),
+        _ => Vec::new(),
+    }
+}
+
 // Create TS method signature from Candid function
 fn create_method_signature(
     top_level_nodes: &mut TopLevelNodes,
     env: &TypeEnv,
     method_id: &str,
     func: &Function,
+    syntax: Option<&IDLType>,
     span: Span,
 ) -> TsTypeElement {
+    let arg_names = func_arg_names(syntax);
     // Create parameters
     let params = func
         .args
         .iter()
         .enumerate()
         .map(|(i, arg_ty)| {
-            let var_name = arg_ty.name.clone().unwrap_or_else(|| format!("arg{}", i));
+            let var_name = arg_names
+                .get(i)
+                .and_then(|n| n.clone())
+                .unwrap_or_else(|| format!("arg{}", i));
             TsFnParam::Ident(BindingIdent {
                 id: Ident::new(var_name.into(), DUMMY_SP, SyntaxContext::empty()),
                 type_ann: Some(Box::new(TsTypeAnn {
                     span: DUMMY_SP,
-                    type_ann: Box::new(convert_type(top_level_nodes, env, &arg_ty.typ, None, true)),
+                    type_ann: Box::new(convert_type(top_level_nodes, env, arg_ty, None, true)),
                 })),
             })
         })
@@ -928,7 +955,7 @@ fn create_method_signature(
             span: DUMMY_SP,
             kind: TsKeywordTypeKind::TsVoidKeyword,
         }),
-        1 => convert_type(top_level_nodes, env, &func.rets[0].typ, None, true),
+        1 => convert_type(top_level_nodes, env, &func.rets[0], None, true),
         _ => {
             // Create a tuple type for multiple return values
             TsType::TsTupleType(TsTupleType {
@@ -939,7 +966,7 @@ fn create_method_signature(
                     .map(|ret| TsTupleElement {
                         span: DUMMY_SP,
                         label: None,
-                        ty: Box::new(convert_type(top_level_nodes, env, &ret.typ, None, true)),
+                        ty: Box::new(convert_type(top_level_nodes, env, ret, None, true)),
                     })
                     .collect(),
             })
@@ -979,19 +1006,24 @@ fn create_function_type(
     top_level_nodes: &mut TopLevelNodes,
     env: &TypeEnv,
     func: &Function,
+    syntax: Option<&IDLType>,
 ) -> TsType {
+    let arg_names = func_arg_names(syntax);
     // Create parameters
     let params = func
         .args
         .iter()
         .enumerate()
         .map(|(i, arg_ty)| {
-            let var_name = arg_ty.name.clone().unwrap_or_else(|| format!("arg{}", i));
+            let var_name = arg_names
+                .get(i)
+                .and_then(|n| n.clone())
+                .unwrap_or_else(|| format!("arg{}", i));
             TsFnParam::Ident(BindingIdent {
                 id: Ident::new(var_name.into(), DUMMY_SP, SyntaxContext::empty()),
                 type_ann: Some(Box::new(TsTypeAnn {
                     span: DUMMY_SP,
-                    type_ann: Box::new(convert_type(top_level_nodes, env, &arg_ty.typ, None, true)),
+                    type_ann: Box::new(convert_type(top_level_nodes, env, arg_ty, None, true)),
                 })),
             })
         })
@@ -1003,7 +1035,7 @@ fn create_function_type(
             span: DUMMY_SP,
             kind: TsKeywordTypeKind::TsVoidKeyword,
         }),
-        1 => convert_type(top_level_nodes, env, &func.rets[0].typ, None, true),
+        1 => convert_type(top_level_nodes, env, &func.rets[0], None, true),
         _ => {
             // Create a tuple type for multiple return values
             TsType::TsTupleType(TsTupleType {
@@ -1014,7 +1046,7 @@ fn create_function_type(
                     .map(|ret| TsTupleElement {
                         span: DUMMY_SP,
                         label: None,
-                        ty: Box::new(convert_type(top_level_nodes, env, &ret.typ, None, true)),
+                        ty: Box::new(convert_type(top_level_nodes, env, ret, None, true)),
                     })
                     .collect(),
             })

--- a/src/core/generate/rs/src/bindings/typescript_native/new_typescript_native_types.rs
+++ b/src/core/generate/rs/src/bindings/typescript_native/new_typescript_native_types.rs
@@ -592,128 +592,119 @@ pub fn add_type_definitions(
     module: &mut Module,
     prog: &IDLMergedProg,
 ) {
-    for id in env.0.keys() {
-        if let Ok(ty) = env.find_type(id) {
-            let syntax = prog.lookup(id.as_str());
-            let syntax_ty = syntax.map(|s| &s.typ);
-            let span = syntax
-                .map(|s| add_comments(top_level_nodes, s.docs.as_ref()))
-                .unwrap_or(DUMMY_SP);
-            match ty.as_ref() {
-                TypeInner::Record(_) if !is_tuple(ty) => {
-                    // Generate interface for record types
-                    let interface = create_interface_from_record(
-                        top_level_nodes,
-                        env,
-                        id.as_str(),
-                        ty,
-                        syntax_ty,
-                    );
-                    module
-                        .body
-                        .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                            span: DUMMY_SP,
-                            decl: Decl::TsInterface(Box::new(interface)),
-                        })));
-                }
-                TypeInner::Service(serv) => {
-                    // Generate interface for service types
-                    let interface = create_interface_from_service(
-                        top_level_nodes,
-                        env,
-                        id.as_str(),
-                        syntax_ty,
-                        serv,
-                    );
-                    module
-                        .body
-                        .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                            span: DUMMY_SP,
-                            decl: Decl::TsInterface(Box::new(interface)),
-                        })));
-                }
-                TypeInner::Func(func) => {
-                    // Generate type alias for function types
-                    let type_alias = create_type_alias_from_function(
-                        top_level_nodes,
-                        env,
-                        id.as_str(),
-                        func,
-                        syntax_ty,
-                    );
-                    module
-                        .body
-                        .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                            span: DUMMY_SP,
-                            decl: Decl::TsTypeAlias(Box::new(type_alias)),
-                        })));
-                }
-                TypeInner::Variant(fs) => {
-                    // Check if all variants have null type
-                    let all_null = fs.iter().all(|f| matches!(f.ty.as_ref(), TypeInner::Null));
+    // Emit type definitions in sorted (alphabetical) order for deterministic
+    // output, matching the other binding generators (see `to_sorted_iter` in
+    // typescript.rs / javascript.rs).
+    for (id, ty) in env.to_sorted_iter() {
+        let syntax = prog.lookup(id.as_str());
+        let syntax_ty = syntax.map(|s| &s.typ);
+        let span = syntax
+            .map(|s| add_comments(top_level_nodes, s.docs.as_ref()))
+            .unwrap_or(DUMMY_SP);
+        match ty.as_ref() {
+            TypeInner::Record(_) if !is_tuple(ty) => {
+                // Generate interface for record types
+                let interface =
+                    create_interface_from_record(top_level_nodes, env, id.as_str(), ty, syntax_ty);
+                module
+                    .body
+                    .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                        span: DUMMY_SP,
+                        decl: Decl::TsInterface(Box::new(interface)),
+                    })));
+            }
+            TypeInner::Service(serv) => {
+                // Generate interface for service types
+                let interface = create_interface_from_service(
+                    top_level_nodes,
+                    env,
+                    id.as_str(),
+                    syntax_ty,
+                    serv,
+                );
+                module
+                    .body
+                    .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                        span: DUMMY_SP,
+                        decl: Decl::TsInterface(Box::new(interface)),
+                    })));
+            }
+            TypeInner::Func(func) => {
+                // Generate type alias for function types
+                let type_alias = create_type_alias_from_function(
+                    top_level_nodes,
+                    env,
+                    id.as_str(),
+                    func,
+                    syntax_ty,
+                );
+                module
+                    .body
+                    .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                        span: DUMMY_SP,
+                        decl: Decl::TsTypeAlias(Box::new(type_alias)),
+                    })));
+            }
+            TypeInner::Variant(fs) => {
+                // Check if all variants have null type
+                let all_null = fs.iter().all(|f| matches!(f.ty.as_ref(), TypeInner::Null));
 
-                    if all_null {
-                        // For variants with all null types, directly create the enum
-                        // Don't create a type alias
+                if all_null {
+                    // For variants with all null types, directly create the enum
+                    // Don't create a type alias
+                    create_variant_type(top_level_nodes, env, syntax_ty, fs, Some(id.as_str()));
+                } else {
+                    // For other variants, create a type alias to the union type
+                    let variant_type =
                         create_variant_type(top_level_nodes, env, syntax_ty, fs, Some(id.as_str()));
-                    } else {
-                        // For other variants, create a type alias to the union type
-                        let variant_type = create_variant_type(
-                            top_level_nodes,
-                            env,
-                            syntax_ty,
-                            fs,
-                            Some(id.as_str()),
-                        );
-                        let type_alias = TsTypeAliasDecl {
-                            span: DUMMY_SP,
-                            declare: false,
-                            id: get_ident_guarded(id.as_str()),
-                            type_params: None,
-                            type_ann: Box::new(variant_type),
-                        };
-                        module
-                            .body
-                            .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                                span: DUMMY_SP,
-                                decl: Decl::TsTypeAlias(Box::new(type_alias)),
-                            })));
-                    }
-                }
-                TypeInner::Var(inner_id) => {
-                    let inner_type = env.rec_find_type(inner_id).unwrap();
-                    let inner_name = match inner_type.as_ref() {
-                        TypeInner::Service(_) => service_interface_ident(inner_id.as_str()),
-                        _ => get_ident_guarded(inner_id.as_str()),
-                    };
                     let type_alias = TsTypeAliasDecl {
                         span: DUMMY_SP,
                         declare: false,
                         id: get_ident_guarded(id.as_str()),
                         type_params: None,
-                        type_ann: Box::new(TsType::TsTypeRef(TsTypeRef {
-                            span: DUMMY_SP,
-                            type_name: TsEntityName::Ident(inner_name),
-                            type_params: None,
-                        })),
+                        type_ann: Box::new(variant_type),
                     };
                     module
                         .body
                         .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                            span,
+                            span: DUMMY_SP,
                             decl: Decl::TsTypeAlias(Box::new(type_alias)),
                         })));
                 }
-                _ => {
-                    // Generate type alias for other types
-                    let type_alias = create_type_alias(top_level_nodes, env, id.as_str(), ty);
-                    module
-                        .body
-                        .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                            span,
-                            decl: Decl::TsTypeAlias(Box::new(type_alias)),
-                        })));
-                }
+            }
+            TypeInner::Var(inner_id) => {
+                let inner_type = env.rec_find_type(inner_id).unwrap();
+                let inner_name = match inner_type.as_ref() {
+                    TypeInner::Service(_) => service_interface_ident(inner_id.as_str()),
+                    _ => get_ident_guarded(inner_id.as_str()),
+                };
+                let type_alias = TsTypeAliasDecl {
+                    span: DUMMY_SP,
+                    declare: false,
+                    id: get_ident_guarded(id.as_str()),
+                    type_params: None,
+                    type_ann: Box::new(TsType::TsTypeRef(TsTypeRef {
+                        span: DUMMY_SP,
+                        type_name: TsEntityName::Ident(inner_name),
+                        type_params: None,
+                    })),
+                };
+                module
+                    .body
+                    .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                        span,
+                        decl: Decl::TsTypeAlias(Box::new(type_alias)),
+                    })));
+            }
+            _ => {
+                // Generate type alias for other types
+                let type_alias = create_type_alias(top_level_nodes, env, id.as_str(), ty);
+                module
+                    .body
+                    .push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                        span,
+                        decl: Decl::TsTypeAlias(Box::new(type_alias)),
+                    })));
             }
         }
     }

--- a/src/core/generate/rs/src/bindings/typescript_native/original_typescript_types.rs
+++ b/src/core/generate/rs/src/bindings/typescript_native/original_typescript_types.rs
@@ -1,4 +1,3 @@
-use candid::types::internal::TypeKey;
 use candid::types::{Field, Label, Type, TypeEnv, TypeInner};
 use std::collections::HashSet;
 use swc_core::common::{DUMMY_SP, SyntaxContext};
@@ -41,7 +40,7 @@ impl<'a> OriginalTypescriptTypes<'a> {
         self.required_candid_imports.insert(type_id.to_string());
     }
 
-    fn create_var_type(&mut self, id: &TypeKey) -> TsType {
+    fn create_var_type(&mut self, id: &str) -> TsType {
         let ty = self.env.rec_find_type(id).unwrap();
         if matches!(ty.as_ref(), TypeInner::Func(_)) {
             return self.create_inline_actor_method();
@@ -50,11 +49,11 @@ impl<'a> OriginalTypescriptTypes<'a> {
             return self.create_inline_service();
         }
         // For named types, use the imported Candid type
-        self.add_required_import(id.as_str());
+        self.add_required_import(id);
         TsType::TsTypeRef(TsTypeRef {
             span: DUMMY_SP,
             type_name: TsEntityName::Ident(Ident::new(
-                format!("_{}", id.as_str()).into(),
+                format!("_{}", id).into(),
                 DUMMY_SP,
                 SyntaxContext::empty(),
             )),

--- a/src/core/generate/rs/src/parser.rs
+++ b/src/core/generate/rs/src/parser.rs
@@ -143,7 +143,7 @@ fn check_defs(env: &mut Env, decs: &[Dec]) -> Result<()> {
         match dec {
             Dec::TypD(Binding { id, typ, docs: _ }) => {
                 let t = check_type(env, typ)?;
-                env.te.0.insert(id.clone().into(), t);
+                env.te.0.insert(id.clone(), t);
             }
             Dec::ImportType(_) | Dec::ImportServ(_) => (),
         }

--- a/src/core/generate/rs/src/parser.rs
+++ b/src/core/generate/rs/src/parser.rs
@@ -2,7 +2,7 @@
 //! that uses Node.js's fs from [crate::fs] to read the imported files.
 
 use crate::fs::read_file_utf8;
-use candid::types::{ArgType, Field, Function, Type, TypeEnv, TypeInner};
+use candid::types::{Field, Function, Type, TypeEnv, TypeInner};
 use candid_parser::{
     Error, Result, pretty_parse,
     syntax::{
@@ -47,7 +47,7 @@ pub fn check_type(env: &Env, t: &IDLType) -> Result<Type> {
     match t {
         IDLType::PrimT(prim) => Ok(check_prim(prim)),
         IDLType::VarT(id) => {
-            let key = id.as_str().into();
+            let key = id.clone();
             env.te.find_type(&key)?;
             Ok(TypeInner::Var(key).into())
         }
@@ -101,11 +101,11 @@ pub fn check_type(env: &Env, t: &IDLType) -> Result<Type> {
     }
 }
 
-fn check_arg(env: &Env, arg: &IDLArgType) -> Result<ArgType> {
-    Ok(ArgType {
-        name: arg.name.clone(),
-        typ: check_type(env, &arg.typ)?,
-    })
+// Candid's `Function`/`Class` types (candid 0.10) do not carry argument names,
+// so we drop the name here and only keep the checked type. Argument names are
+// recovered from the syntax AST (`IDLArgType.name`) by the binding generators.
+fn check_arg(env: &Env, arg: &IDLArgType) -> Result<Type> {
+    check_type(env, &arg.typ)
 }
 
 fn check_fields(env: &Env, fs: &[TypeField]) -> Result<Vec<Field>> {

--- a/tests/snapshots/generate/example/example.d.ts.snapshot
+++ b/tests/snapshots/generate/example/example.d.ts.snapshot
@@ -17,6 +17,32 @@ export interface None {
     __kind__: "None";
 }
 export type Option<T> = Some<T> | None;
+export type A = B;
+export type B = Some<A> | None;
+/**
+ * Doc comment for List
+ */
+export type List = {
+    head: bigint;
+    tail: List;
+} | null;
+export type a = {
+    __kind__: "a";
+    a: null;
+} | {
+    __kind__: "b";
+    b: b;
+};
+export type b = [bigint, bigint];
+export interface brokerInterface {
+    find(name: string): Promise<Principal>;
+}
+export type f = (arg0: List, arg1: [Principal, string]) => Promise<[List | null, res]>;
+export type list = node | null;
+/**
+ * Doc comment for prim type
+ */
+export type my_type = Principal;
 export type my_variant = {
     __kind__: "a";
     /**
@@ -40,25 +66,6 @@ export type my_variant = {
         }>;
     } | null;
 };
-export type res = {
-    __kind__: "Ok";
-    /**
-     * Doc comment for Ok variant
-     */
-    Ok: [bigint, bigint];
-} | {
-    __kind__: "Err";
-    /**
-     * Doc comment for Err variant
-     */
-    Err: {
-        /**
-         * Doc comment for error field in Err variant,
-         * on multiple lines
-         */
-        error: string;
-    };
-};
 export interface nested {
     _0_: bigint;
     _1_: bigint;
@@ -75,11 +82,15 @@ export interface nested {
     _41_: Variant__42__A_B_C;
     _42_: bigint;
 }
-export interface node {
-    head: bigint;
-    tail: list;
+export type nested_opt = Some<bigint | null> | None;
+export interface nested_records {
+    /**
+     * Doc comment for nested_records field nested
+     */
+    nested?: {
+        nested_field: string;
+    };
 }
-export type A = B;
 export type nested_res = {
     __kind__: "Ok";
     Ok: Variant_Ok_Err;
@@ -101,15 +112,38 @@ export type nested_res = {
         Err: [bigint];
     };
 };
-export type B = Some<A> | None;
-export interface nested_records {
-    /**
-     * Doc comment for nested_records field nested
-     */
-    nested?: {
-        nested_field: string;
-    };
+export interface node {
+    head: bigint;
+    tail: list;
 }
+export type res = {
+    __kind__: "Ok";
+    /**
+     * Doc comment for Ok variant
+     */
+    Ok: [bigint, bigint];
+} | {
+    __kind__: "Err";
+    /**
+     * Doc comment for Err variant
+     */
+    Err: {
+        /**
+         * Doc comment for error field in Err variant,
+         * on multiple lines
+         */
+        error: string;
+    };
+};
+export interface sInterface {
+    f: t;
+    g(arg0: list): Promise<[B, tree, stream]>;
+}
+export type stream = {
+    head: bigint;
+    next: [Principal, string];
+} | null;
+export type t = (server: Principal) => Promise<void>;
 export type tree = {
     __kind__: "branch";
     branch: {
@@ -121,40 +155,6 @@ export type tree = {
     __kind__: "leaf";
     leaf: bigint;
 };
-export type f = (arg0: List, arg1: [Principal, string]) => Promise<[List | null, res]>;
-export interface brokerInterface {
-    find(name: string): Promise<Principal>;
-}
-export type nested_opt = Some<bigint | null> | None;
-/**
- * Doc comment for prim type
- */
-export type my_type = Principal;
-/**
- * Doc comment for List
- */
-export type List = {
-    head: bigint;
-    tail: List;
-} | null;
-export type list = node | null;
-export interface sInterface {
-    f: t;
-    g(arg0: list): Promise<[B, tree, stream]>;
-}
-export type stream = {
-    head: bigint;
-    next: [Principal, string];
-} | null;
-export type b = [bigint, bigint];
-export type a = {
-    __kind__: "a";
-    a: null;
-} | {
-    __kind__: "b";
-    b: b;
-};
-export type t = (server: Principal) => Promise<void>;
 export enum Variant_Ok_Err {
     Ok = "Ok",
     Err = "Err"

--- a/tests/snapshots/generate/example/example.d.ts.snapshot
+++ b/tests/snapshots/generate/example/example.d.ts.snapshot
@@ -34,6 +34,9 @@ export type a = {
     b: b;
 };
 export type b = [bigint, bigint];
+/**
+ * Doc comment for broker service
+ */
 export interface brokerInterface {
     find(name: string): Promise<Principal>;
 }
@@ -66,6 +69,9 @@ export type my_variant = {
         }>;
     } | null;
 };
+/**
+ * Doc comment for nested type
+ */
 export interface nested {
     _0_: bigint;
     _1_: bigint;
@@ -83,6 +89,9 @@ export interface nested {
     _42_: bigint;
 }
 export type nested_opt = Some<bigint | null> | None;
+/**
+ * Doc comment for nested_records
+ */
 export interface nested_records {
     /**
      * Doc comment for nested_records field nested
@@ -116,6 +125,9 @@ export interface node {
     head: bigint;
     tail: list;
 }
+/**
+ * Doc comment for res type
+ */
 export type res = {
     __kind__: "Ok";
     /**
@@ -135,6 +147,9 @@ export type res = {
         error: string;
     };
 };
+/**
+ * Doc comment for service id
+ */
 export interface sInterface {
     f: t;
     g(arg0: list): Promise<[B, tree, stream]>;

--- a/tests/snapshots/generate/example/example.ts.snapshot
+++ b/tests/snapshots/generate/example/example.ts.snapshot
@@ -51,6 +51,32 @@ function candid_none<T>(): [] {
 function record_opt_to_undefined<T>(arg: T | null): T | undefined {
     return arg == null ? undefined : arg;
 }
+export type A = B;
+export type B = Some<A> | None;
+/**
+ * Doc comment for List
+ */
+export type List = {
+    head: bigint;
+    tail: List;
+} | null;
+export type a = {
+    __kind__: "a";
+    a: null;
+} | {
+    __kind__: "b";
+    b: b;
+};
+export type b = [bigint, bigint];
+export interface brokerInterface {
+    find(name: string): Promise<Principal>;
+}
+export type f = (arg0: List, arg1: [Principal, string]) => Promise<[List | null, res]>;
+export type list = node | null;
+/**
+ * Doc comment for prim type
+ */
+export type my_type = Principal;
 export type my_variant = {
     __kind__: "a";
     /**
@@ -74,25 +100,6 @@ export type my_variant = {
         }>;
     } | null;
 };
-export type res = {
-    __kind__: "Ok";
-    /**
-     * Doc comment for Ok variant
-     */
-    Ok: [bigint, bigint];
-} | {
-    __kind__: "Err";
-    /**
-     * Doc comment for Err variant
-     */
-    Err: {
-        /**
-         * Doc comment for error field in Err variant,
-         * on multiple lines
-         */
-        error: string;
-    };
-};
 export interface nested {
     _0_: bigint;
     _1_: bigint;
@@ -109,11 +116,15 @@ export interface nested {
     _41_: Variant__42__A_B_C;
     _42_: bigint;
 }
-export interface node {
-    head: bigint;
-    tail: list;
+export type nested_opt = Some<bigint | null> | None;
+export interface nested_records {
+    /**
+     * Doc comment for nested_records field nested
+     */
+    nested?: {
+        nested_field: string;
+    };
 }
-export type A = B;
 export type nested_res = {
     __kind__: "Ok";
     Ok: Variant_Ok_Err;
@@ -135,15 +146,38 @@ export type nested_res = {
         Err: [bigint];
     };
 };
-export type B = Some<A> | None;
-export interface nested_records {
-    /**
-     * Doc comment for nested_records field nested
-     */
-    nested?: {
-        nested_field: string;
-    };
+export interface node {
+    head: bigint;
+    tail: list;
 }
+export type res = {
+    __kind__: "Ok";
+    /**
+     * Doc comment for Ok variant
+     */
+    Ok: [bigint, bigint];
+} | {
+    __kind__: "Err";
+    /**
+     * Doc comment for Err variant
+     */
+    Err: {
+        /**
+         * Doc comment for error field in Err variant,
+         * on multiple lines
+         */
+        error: string;
+    };
+};
+export interface sInterface {
+    f: t;
+    g(arg0: list): Promise<[B, tree, stream]>;
+}
+export type stream = {
+    head: bigint;
+    next: [Principal, string];
+} | null;
+export type t = (server: Principal) => Promise<void>;
 export type tree = {
     __kind__: "branch";
     branch: {
@@ -155,40 +189,6 @@ export type tree = {
     __kind__: "leaf";
     leaf: bigint;
 };
-export type f = (arg0: List, arg1: [Principal, string]) => Promise<[List | null, res]>;
-export interface brokerInterface {
-    find(name: string): Promise<Principal>;
-}
-export type nested_opt = Some<bigint | null> | None;
-/**
- * Doc comment for prim type
- */
-export type my_type = Principal;
-/**
- * Doc comment for List
- */
-export type List = {
-    head: bigint;
-    tail: List;
-} | null;
-export type list = node | null;
-export interface sInterface {
-    f: t;
-    g(arg0: list): Promise<[B, tree, stream]>;
-}
-export type stream = {
-    head: bigint;
-    next: [Principal, string];
-} | null;
-export type b = [bigint, bigint];
-export type a = {
-    __kind__: "a";
-    a: null;
-} | {
-    __kind__: "b";
-    b: b;
-};
-export type t = (server: Principal) => Promise<void>;
 export enum Variant_Ok_Err {
     Ok = "Ok",
     Err = "Err"

--- a/tests/snapshots/generate/example/example.ts.snapshot
+++ b/tests/snapshots/generate/example/example.ts.snapshot
@@ -68,6 +68,9 @@ export type a = {
     b: b;
 };
 export type b = [bigint, bigint];
+/**
+ * Doc comment for broker service
+ */
 export interface brokerInterface {
     find(name: string): Promise<Principal>;
 }
@@ -100,6 +103,9 @@ export type my_variant = {
         }>;
     } | null;
 };
+/**
+ * Doc comment for nested type
+ */
 export interface nested {
     _0_: bigint;
     _1_: bigint;
@@ -117,6 +123,9 @@ export interface nested {
     _42_: bigint;
 }
 export type nested_opt = Some<bigint | null> | None;
+/**
+ * Doc comment for nested_records
+ */
 export interface nested_records {
     /**
      * Doc comment for nested_records field nested
@@ -150,6 +159,9 @@ export interface node {
     head: bigint;
     tail: list;
 }
+/**
+ * Doc comment for res type
+ */
 export type res = {
     __kind__: "Ok";
     /**
@@ -169,6 +181,9 @@ export type res = {
         error: string;
     };
 };
+/**
+ * Doc comment for service id
+ */
 export interface sInterface {
     f: t;
     g(arg0: list): Promise<[B, tree, stream]>;

--- a/tests/snapshots/wasm-generate/malicious_doc/malicious_doc.d.ts.snapshot
+++ b/tests/snapshots/wasm-generate/malicious_doc/malicious_doc.d.ts.snapshot
@@ -9,6 +9,11 @@ export interface None {
     __kind__: "None";
 }
 export type Option<T> = Some<T> | None;
+/**
+ * *\/ import { malicious } from 'attacker'; console.log('injected!'); /*
+ * Normal doc line
+ * Another *\/ attempt /* to inject
+ */
 export interface MaliciousType {
     /**
      * Doc comment for field with *\/ malicious code /* in it

--- a/tests/snapshots/wasm-generate/malicious_doc/malicious_doc.ts.snapshot
+++ b/tests/snapshots/wasm-generate/malicious_doc/malicious_doc.ts.snapshot
@@ -43,6 +43,11 @@ function candid_none<T>(): [] {
 function record_opt_to_undefined<T>(arg: T | null): T | undefined {
     return arg == null ? undefined : arg;
 }
+/**
+ * *\/ import { malicious } from 'attacker'; console.log('injected!'); /*
+ * Normal doc line
+ * Another *\/ attempt /* to inject
+ */
 export interface MaliciousType {
     /**
      * Doc comment for field with *\/ malicious code /* in it

--- a/tests/snapshots/wasm-generate/no-root-export/example/example.d.ts.snapshot
+++ b/tests/snapshots/wasm-generate/no-root-export/example/example.d.ts.snapshot
@@ -26,6 +26,9 @@ export type a = {
     b: b;
 };
 export type b = [bigint, bigint];
+/**
+ * Doc comment for broker service
+ */
 export interface brokerInterface {
     find(name: string): Promise<Principal>;
 }
@@ -58,6 +61,9 @@ export type my_variant = {
         }>;
     } | null;
 };
+/**
+ * Doc comment for nested type
+ */
 export interface nested {
     _0_: bigint;
     _1_: bigint;
@@ -75,6 +81,9 @@ export interface nested {
     _42_: bigint;
 }
 export type nested_opt = Some<bigint | null> | None;
+/**
+ * Doc comment for nested_records
+ */
 export interface nested_records {
     /**
      * Doc comment for nested_records field nested
@@ -108,6 +117,9 @@ export interface node {
     head: bigint;
     tail: list;
 }
+/**
+ * Doc comment for res type
+ */
 export type res = {
     __kind__: "Ok";
     /**
@@ -127,6 +139,9 @@ export type res = {
         error: string;
     };
 };
+/**
+ * Doc comment for service id
+ */
 export interface sInterface {
     f: t;
     g(arg0: list): Promise<[B, tree, stream]>;

--- a/tests/snapshots/wasm-generate/no-root-export/example/example.d.ts.snapshot
+++ b/tests/snapshots/wasm-generate/no-root-export/example/example.d.ts.snapshot
@@ -9,6 +9,32 @@ export interface None {
     __kind__: "None";
 }
 export type Option<T> = Some<T> | None;
+export type A = B;
+export type B = Some<A> | None;
+/**
+ * Doc comment for List
+ */
+export type List = {
+    head: bigint;
+    tail: List;
+} | null;
+export type a = {
+    __kind__: "a";
+    a: null;
+} | {
+    __kind__: "b";
+    b: b;
+};
+export type b = [bigint, bigint];
+export interface brokerInterface {
+    find(name: string): Promise<Principal>;
+}
+export type f = (arg0: List, arg1: [Principal, string]) => Promise<[List | null, res]>;
+export type list = node | null;
+/**
+ * Doc comment for prim type
+ */
+export type my_type = Principal;
 export type my_variant = {
     __kind__: "a";
     /**
@@ -32,25 +58,6 @@ export type my_variant = {
         }>;
     } | null;
 };
-export type res = {
-    __kind__: "Ok";
-    /**
-     * Doc comment for Ok variant
-     */
-    Ok: [bigint, bigint];
-} | {
-    __kind__: "Err";
-    /**
-     * Doc comment for Err variant
-     */
-    Err: {
-        /**
-         * Doc comment for error field in Err variant,
-         * on multiple lines
-         */
-        error: string;
-    };
-};
 export interface nested {
     _0_: bigint;
     _1_: bigint;
@@ -67,11 +74,15 @@ export interface nested {
     _41_: Variant__42__A_B_C;
     _42_: bigint;
 }
-export interface node {
-    head: bigint;
-    tail: list;
+export type nested_opt = Some<bigint | null> | None;
+export interface nested_records {
+    /**
+     * Doc comment for nested_records field nested
+     */
+    nested?: {
+        nested_field: string;
+    };
 }
-export type A = B;
 export type nested_res = {
     __kind__: "Ok";
     Ok: Variant_Ok_Err;
@@ -93,15 +104,38 @@ export type nested_res = {
         Err: [bigint];
     };
 };
-export type B = Some<A> | None;
-export interface nested_records {
-    /**
-     * Doc comment for nested_records field nested
-     */
-    nested?: {
-        nested_field: string;
-    };
+export interface node {
+    head: bigint;
+    tail: list;
 }
+export type res = {
+    __kind__: "Ok";
+    /**
+     * Doc comment for Ok variant
+     */
+    Ok: [bigint, bigint];
+} | {
+    __kind__: "Err";
+    /**
+     * Doc comment for Err variant
+     */
+    Err: {
+        /**
+         * Doc comment for error field in Err variant,
+         * on multiple lines
+         */
+        error: string;
+    };
+};
+export interface sInterface {
+    f: t;
+    g(arg0: list): Promise<[B, tree, stream]>;
+}
+export type stream = {
+    head: bigint;
+    next: [Principal, string];
+} | null;
+export type t = (server: Principal) => Promise<void>;
 export type tree = {
     __kind__: "branch";
     branch: {
@@ -113,40 +147,6 @@ export type tree = {
     __kind__: "leaf";
     leaf: bigint;
 };
-export type f = (arg0: List, arg1: [Principal, string]) => Promise<[List | null, res]>;
-export interface brokerInterface {
-    find(name: string): Promise<Principal>;
-}
-export type nested_opt = Some<bigint | null> | None;
-/**
- * Doc comment for prim type
- */
-export type my_type = Principal;
-/**
- * Doc comment for List
- */
-export type List = {
-    head: bigint;
-    tail: List;
-} | null;
-export type list = node | null;
-export interface sInterface {
-    f: t;
-    g(arg0: list): Promise<[B, tree, stream]>;
-}
-export type stream = {
-    head: bigint;
-    next: [Principal, string];
-} | null;
-export type b = [bigint, bigint];
-export type a = {
-    __kind__: "a";
-    a: null;
-} | {
-    __kind__: "b";
-    b: b;
-};
-export type t = (server: Principal) => Promise<void>;
 export enum Variant_Ok_Err {
     Ok = "Ok",
     Err = "Err"

--- a/tests/snapshots/wasm-generate/no-root-export/example/example.ts.snapshot
+++ b/tests/snapshots/wasm-generate/no-root-export/example/example.ts.snapshot
@@ -60,6 +60,9 @@ export type a = {
     b: b;
 };
 export type b = [bigint, bigint];
+/**
+ * Doc comment for broker service
+ */
 export interface brokerInterface {
     find(name: string): Promise<Principal>;
 }
@@ -92,6 +95,9 @@ export type my_variant = {
         }>;
     } | null;
 };
+/**
+ * Doc comment for nested type
+ */
 export interface nested {
     _0_: bigint;
     _1_: bigint;
@@ -109,6 +115,9 @@ export interface nested {
     _42_: bigint;
 }
 export type nested_opt = Some<bigint | null> | None;
+/**
+ * Doc comment for nested_records
+ */
 export interface nested_records {
     /**
      * Doc comment for nested_records field nested
@@ -142,6 +151,9 @@ export interface node {
     head: bigint;
     tail: list;
 }
+/**
+ * Doc comment for res type
+ */
 export type res = {
     __kind__: "Ok";
     /**
@@ -161,6 +173,9 @@ export type res = {
         error: string;
     };
 };
+/**
+ * Doc comment for service id
+ */
 export interface sInterface {
     f: t;
     g(arg0: list): Promise<[B, tree, stream]>;

--- a/tests/snapshots/wasm-generate/no-root-export/example/example.ts.snapshot
+++ b/tests/snapshots/wasm-generate/no-root-export/example/example.ts.snapshot
@@ -43,6 +43,32 @@ function candid_none<T>(): [] {
 function record_opt_to_undefined<T>(arg: T | null): T | undefined {
     return arg == null ? undefined : arg;
 }
+export type A = B;
+export type B = Some<A> | None;
+/**
+ * Doc comment for List
+ */
+export type List = {
+    head: bigint;
+    tail: List;
+} | null;
+export type a = {
+    __kind__: "a";
+    a: null;
+} | {
+    __kind__: "b";
+    b: b;
+};
+export type b = [bigint, bigint];
+export interface brokerInterface {
+    find(name: string): Promise<Principal>;
+}
+export type f = (arg0: List, arg1: [Principal, string]) => Promise<[List | null, res]>;
+export type list = node | null;
+/**
+ * Doc comment for prim type
+ */
+export type my_type = Principal;
 export type my_variant = {
     __kind__: "a";
     /**
@@ -66,25 +92,6 @@ export type my_variant = {
         }>;
     } | null;
 };
-export type res = {
-    __kind__: "Ok";
-    /**
-     * Doc comment for Ok variant
-     */
-    Ok: [bigint, bigint];
-} | {
-    __kind__: "Err";
-    /**
-     * Doc comment for Err variant
-     */
-    Err: {
-        /**
-         * Doc comment for error field in Err variant,
-         * on multiple lines
-         */
-        error: string;
-    };
-};
 export interface nested {
     _0_: bigint;
     _1_: bigint;
@@ -101,11 +108,15 @@ export interface nested {
     _41_: Variant__42__A_B_C;
     _42_: bigint;
 }
-export interface node {
-    head: bigint;
-    tail: list;
+export type nested_opt = Some<bigint | null> | None;
+export interface nested_records {
+    /**
+     * Doc comment for nested_records field nested
+     */
+    nested?: {
+        nested_field: string;
+    };
 }
-export type A = B;
 export type nested_res = {
     __kind__: "Ok";
     Ok: Variant_Ok_Err;
@@ -127,15 +138,38 @@ export type nested_res = {
         Err: [bigint];
     };
 };
-export type B = Some<A> | None;
-export interface nested_records {
-    /**
-     * Doc comment for nested_records field nested
-     */
-    nested?: {
-        nested_field: string;
-    };
+export interface node {
+    head: bigint;
+    tail: list;
 }
+export type res = {
+    __kind__: "Ok";
+    /**
+     * Doc comment for Ok variant
+     */
+    Ok: [bigint, bigint];
+} | {
+    __kind__: "Err";
+    /**
+     * Doc comment for Err variant
+     */
+    Err: {
+        /**
+         * Doc comment for error field in Err variant,
+         * on multiple lines
+         */
+        error: string;
+    };
+};
+export interface sInterface {
+    f: t;
+    g(arg0: list): Promise<[B, tree, stream]>;
+}
+export type stream = {
+    head: bigint;
+    next: [Principal, string];
+} | null;
+export type t = (server: Principal) => Promise<void>;
 export type tree = {
     __kind__: "branch";
     branch: {
@@ -147,40 +181,6 @@ export type tree = {
     __kind__: "leaf";
     leaf: bigint;
 };
-export type f = (arg0: List, arg1: [Principal, string]) => Promise<[List | null, res]>;
-export interface brokerInterface {
-    find(name: string): Promise<Principal>;
-}
-export type nested_opt = Some<bigint | null> | None;
-/**
- * Doc comment for prim type
- */
-export type my_type = Principal;
-/**
- * Doc comment for List
- */
-export type List = {
-    head: bigint;
-    tail: List;
-} | null;
-export type list = node | null;
-export interface sInterface {
-    f: t;
-    g(arg0: list): Promise<[B, tree, stream]>;
-}
-export type stream = {
-    head: bigint;
-    next: [Principal, string];
-} | null;
-export type b = [bigint, bigint];
-export type a = {
-    __kind__: "a";
-    a: null;
-} | {
-    __kind__: "b";
-    b: b;
-};
-export type t = (server: Principal) => Promise<void>;
 export enum Variant_Ok_Err {
     Ok = "Ok",
     Err = "Err"

--- a/tests/snapshots/wasm-generate/root-export/example/example.d.ts.snapshot
+++ b/tests/snapshots/wasm-generate/root-export/example/example.d.ts.snapshot
@@ -26,6 +26,9 @@ export type a = {
     b: b;
 };
 export type b = [bigint, bigint];
+/**
+ * Doc comment for broker service
+ */
 export interface brokerInterface {
     find(name: string): Promise<Principal>;
 }
@@ -58,6 +61,9 @@ export type my_variant = {
         }>;
     } | null;
 };
+/**
+ * Doc comment for nested type
+ */
 export interface nested {
     _0_: bigint;
     _1_: bigint;
@@ -75,6 +81,9 @@ export interface nested {
     _42_: bigint;
 }
 export type nested_opt = Some<bigint | null> | None;
+/**
+ * Doc comment for nested_records
+ */
 export interface nested_records {
     /**
      * Doc comment for nested_records field nested
@@ -108,6 +117,9 @@ export interface node {
     head: bigint;
     tail: list;
 }
+/**
+ * Doc comment for res type
+ */
 export type res = {
     __kind__: "Ok";
     /**
@@ -127,6 +139,9 @@ export type res = {
         error: string;
     };
 };
+/**
+ * Doc comment for service id
+ */
 export interface sInterface {
     f: t;
     g(arg0: list): Promise<[B, tree, stream]>;

--- a/tests/snapshots/wasm-generate/root-export/example/example.d.ts.snapshot
+++ b/tests/snapshots/wasm-generate/root-export/example/example.d.ts.snapshot
@@ -9,6 +9,32 @@ export interface None {
     __kind__: "None";
 }
 export type Option<T> = Some<T> | None;
+export type A = B;
+export type B = Some<A> | None;
+/**
+ * Doc comment for List
+ */
+export type List = {
+    head: bigint;
+    tail: List;
+} | null;
+export type a = {
+    __kind__: "a";
+    a: null;
+} | {
+    __kind__: "b";
+    b: b;
+};
+export type b = [bigint, bigint];
+export interface brokerInterface {
+    find(name: string): Promise<Principal>;
+}
+export type f = (arg0: List, arg1: [Principal, string]) => Promise<[List | null, res]>;
+export type list = node | null;
+/**
+ * Doc comment for prim type
+ */
+export type my_type = Principal;
 export type my_variant = {
     __kind__: "a";
     /**
@@ -32,25 +58,6 @@ export type my_variant = {
         }>;
     } | null;
 };
-export type res = {
-    __kind__: "Ok";
-    /**
-     * Doc comment for Ok variant
-     */
-    Ok: [bigint, bigint];
-} | {
-    __kind__: "Err";
-    /**
-     * Doc comment for Err variant
-     */
-    Err: {
-        /**
-         * Doc comment for error field in Err variant,
-         * on multiple lines
-         */
-        error: string;
-    };
-};
 export interface nested {
     _0_: bigint;
     _1_: bigint;
@@ -67,11 +74,15 @@ export interface nested {
     _41_: Variant__42__A_B_C;
     _42_: bigint;
 }
-export interface node {
-    head: bigint;
-    tail: list;
+export type nested_opt = Some<bigint | null> | None;
+export interface nested_records {
+    /**
+     * Doc comment for nested_records field nested
+     */
+    nested?: {
+        nested_field: string;
+    };
 }
-export type A = B;
 export type nested_res = {
     __kind__: "Ok";
     Ok: Variant_Ok_Err;
@@ -93,15 +104,38 @@ export type nested_res = {
         Err: [bigint];
     };
 };
-export type B = Some<A> | None;
-export interface nested_records {
-    /**
-     * Doc comment for nested_records field nested
-     */
-    nested?: {
-        nested_field: string;
-    };
+export interface node {
+    head: bigint;
+    tail: list;
 }
+export type res = {
+    __kind__: "Ok";
+    /**
+     * Doc comment for Ok variant
+     */
+    Ok: [bigint, bigint];
+} | {
+    __kind__: "Err";
+    /**
+     * Doc comment for Err variant
+     */
+    Err: {
+        /**
+         * Doc comment for error field in Err variant,
+         * on multiple lines
+         */
+        error: string;
+    };
+};
+export interface sInterface {
+    f: t;
+    g(arg0: list): Promise<[B, tree, stream]>;
+}
+export type stream = {
+    head: bigint;
+    next: [Principal, string];
+} | null;
+export type t = (server: Principal) => Promise<void>;
 export type tree = {
     __kind__: "branch";
     branch: {
@@ -113,40 +147,6 @@ export type tree = {
     __kind__: "leaf";
     leaf: bigint;
 };
-export type f = (arg0: List, arg1: [Principal, string]) => Promise<[List | null, res]>;
-export interface brokerInterface {
-    find(name: string): Promise<Principal>;
-}
-export type nested_opt = Some<bigint | null> | None;
-/**
- * Doc comment for prim type
- */
-export type my_type = Principal;
-/**
- * Doc comment for List
- */
-export type List = {
-    head: bigint;
-    tail: List;
-} | null;
-export type list = node | null;
-export interface sInterface {
-    f: t;
-    g(arg0: list): Promise<[B, tree, stream]>;
-}
-export type stream = {
-    head: bigint;
-    next: [Principal, string];
-} | null;
-export type b = [bigint, bigint];
-export type a = {
-    __kind__: "a";
-    a: null;
-} | {
-    __kind__: "b";
-    b: b;
-};
-export type t = (server: Principal) => Promise<void>;
 export enum Variant_Ok_Err {
     Ok = "Ok",
     Err = "Err"

--- a/tests/snapshots/wasm-generate/root-export/example/example.ts.snapshot
+++ b/tests/snapshots/wasm-generate/root-export/example/example.ts.snapshot
@@ -60,6 +60,9 @@ export type a = {
     b: b;
 };
 export type b = [bigint, bigint];
+/**
+ * Doc comment for broker service
+ */
 export interface brokerInterface {
     find(name: string): Promise<Principal>;
 }
@@ -92,6 +95,9 @@ export type my_variant = {
         }>;
     } | null;
 };
+/**
+ * Doc comment for nested type
+ */
 export interface nested {
     _0_: bigint;
     _1_: bigint;
@@ -109,6 +115,9 @@ export interface nested {
     _42_: bigint;
 }
 export type nested_opt = Some<bigint | null> | None;
+/**
+ * Doc comment for nested_records
+ */
 export interface nested_records {
     /**
      * Doc comment for nested_records field nested
@@ -142,6 +151,9 @@ export interface node {
     head: bigint;
     tail: list;
 }
+/**
+ * Doc comment for res type
+ */
 export type res = {
     __kind__: "Ok";
     /**
@@ -161,6 +173,9 @@ export type res = {
         error: string;
     };
 };
+/**
+ * Doc comment for service id
+ */
 export interface sInterface {
     f: t;
     g(arg0: list): Promise<[B, tree, stream]>;

--- a/tests/snapshots/wasm-generate/root-export/example/example.ts.snapshot
+++ b/tests/snapshots/wasm-generate/root-export/example/example.ts.snapshot
@@ -43,6 +43,32 @@ function candid_none<T>(): [] {
 function record_opt_to_undefined<T>(arg: T | null): T | undefined {
     return arg == null ? undefined : arg;
 }
+export type A = B;
+export type B = Some<A> | None;
+/**
+ * Doc comment for List
+ */
+export type List = {
+    head: bigint;
+    tail: List;
+} | null;
+export type a = {
+    __kind__: "a";
+    a: null;
+} | {
+    __kind__: "b";
+    b: b;
+};
+export type b = [bigint, bigint];
+export interface brokerInterface {
+    find(name: string): Promise<Principal>;
+}
+export type f = (arg0: List, arg1: [Principal, string]) => Promise<[List | null, res]>;
+export type list = node | null;
+/**
+ * Doc comment for prim type
+ */
+export type my_type = Principal;
 export type my_variant = {
     __kind__: "a";
     /**
@@ -66,25 +92,6 @@ export type my_variant = {
         }>;
     } | null;
 };
-export type res = {
-    __kind__: "Ok";
-    /**
-     * Doc comment for Ok variant
-     */
-    Ok: [bigint, bigint];
-} | {
-    __kind__: "Err";
-    /**
-     * Doc comment for Err variant
-     */
-    Err: {
-        /**
-         * Doc comment for error field in Err variant,
-         * on multiple lines
-         */
-        error: string;
-    };
-};
 export interface nested {
     _0_: bigint;
     _1_: bigint;
@@ -101,11 +108,15 @@ export interface nested {
     _41_: Variant__42__A_B_C;
     _42_: bigint;
 }
-export interface node {
-    head: bigint;
-    tail: list;
+export type nested_opt = Some<bigint | null> | None;
+export interface nested_records {
+    /**
+     * Doc comment for nested_records field nested
+     */
+    nested?: {
+        nested_field: string;
+    };
 }
-export type A = B;
 export type nested_res = {
     __kind__: "Ok";
     Ok: Variant_Ok_Err;
@@ -127,15 +138,38 @@ export type nested_res = {
         Err: [bigint];
     };
 };
-export type B = Some<A> | None;
-export interface nested_records {
-    /**
-     * Doc comment for nested_records field nested
-     */
-    nested?: {
-        nested_field: string;
-    };
+export interface node {
+    head: bigint;
+    tail: list;
 }
+export type res = {
+    __kind__: "Ok";
+    /**
+     * Doc comment for Ok variant
+     */
+    Ok: [bigint, bigint];
+} | {
+    __kind__: "Err";
+    /**
+     * Doc comment for Err variant
+     */
+    Err: {
+        /**
+         * Doc comment for error field in Err variant,
+         * on multiple lines
+         */
+        error: string;
+    };
+};
+export interface sInterface {
+    f: t;
+    g(arg0: list): Promise<[B, tree, stream]>;
+}
+export type stream = {
+    head: bigint;
+    next: [Principal, string];
+} | null;
+export type t = (server: Principal) => Promise<void>;
 export type tree = {
     __kind__: "branch";
     branch: {
@@ -147,40 +181,6 @@ export type tree = {
     __kind__: "leaf";
     leaf: bigint;
 };
-export type f = (arg0: List, arg1: [Principal, string]) => Promise<[List | null, res]>;
-export interface brokerInterface {
-    find(name: string): Promise<Principal>;
-}
-export type nested_opt = Some<bigint | null> | None;
-/**
- * Doc comment for prim type
- */
-export type my_type = Principal;
-/**
- * Doc comment for List
- */
-export type List = {
-    head: bigint;
-    tail: List;
-} | null;
-export type list = node | null;
-export interface sInterface {
-    f: t;
-    g(arg0: list): Promise<[B, tree, stream]>;
-}
-export type stream = {
-    head: bigint;
-    next: [Principal, string];
-} | null;
-export type b = [bigint, bigint];
-export type a = {
-    __kind__: "a";
-    a: null;
-} | {
-    __kind__: "b";
-    b: b;
-};
-export type t = (server: Principal) => Promise<void>;
 export enum Variant_Ok_Err {
     Ok = "Ok",
     Err = "Err"

--- a/tests/snapshots/wasm-generate/typescript-root-export/example/example.ts.snapshot
+++ b/tests/snapshots/wasm-generate/typescript-root-export/example/example.ts.snapshot
@@ -60,6 +60,9 @@ export type a = {
     b: b;
 };
 export type b = [bigint, bigint];
+/**
+ * Doc comment for broker service
+ */
 export interface brokerInterface {
     find(name: string): Promise<Principal>;
 }
@@ -92,6 +95,9 @@ export type my_variant = {
         }>;
     } | null;
 };
+/**
+ * Doc comment for nested type
+ */
 export interface nested {
     _0_: bigint;
     _1_: bigint;
@@ -109,6 +115,9 @@ export interface nested {
     _42_: bigint;
 }
 export type nested_opt = Some<bigint | null> | None;
+/**
+ * Doc comment for nested_records
+ */
 export interface nested_records {
     /**
      * Doc comment for nested_records field nested
@@ -142,6 +151,9 @@ export interface node {
     head: bigint;
     tail: list;
 }
+/**
+ * Doc comment for res type
+ */
 export type res = {
     __kind__: "Ok";
     /**
@@ -161,6 +173,9 @@ export type res = {
         error: string;
     };
 };
+/**
+ * Doc comment for service id
+ */
 export interface sInterface {
     f: t;
     g(arg0: list): Promise<[B, tree, stream]>;

--- a/tests/snapshots/wasm-generate/typescript-root-export/example/example.ts.snapshot
+++ b/tests/snapshots/wasm-generate/typescript-root-export/example/example.ts.snapshot
@@ -43,6 +43,32 @@ function candid_none<T>(): [] {
 function record_opt_to_undefined<T>(arg: T | null): T | undefined {
     return arg == null ? undefined : arg;
 }
+export type A = B;
+export type B = Some<A> | None;
+/**
+ * Doc comment for List
+ */
+export type List = {
+    head: bigint;
+    tail: List;
+} | null;
+export type a = {
+    __kind__: "a";
+    a: null;
+} | {
+    __kind__: "b";
+    b: b;
+};
+export type b = [bigint, bigint];
+export interface brokerInterface {
+    find(name: string): Promise<Principal>;
+}
+export type f = (arg0: List, arg1: [Principal, string]) => Promise<[List | null, res]>;
+export type list = node | null;
+/**
+ * Doc comment for prim type
+ */
+export type my_type = Principal;
 export type my_variant = {
     __kind__: "a";
     /**
@@ -66,25 +92,6 @@ export type my_variant = {
         }>;
     } | null;
 };
-export type res = {
-    __kind__: "Ok";
-    /**
-     * Doc comment for Ok variant
-     */
-    Ok: [bigint, bigint];
-} | {
-    __kind__: "Err";
-    /**
-     * Doc comment for Err variant
-     */
-    Err: {
-        /**
-         * Doc comment for error field in Err variant,
-         * on multiple lines
-         */
-        error: string;
-    };
-};
 export interface nested {
     _0_: bigint;
     _1_: bigint;
@@ -101,11 +108,15 @@ export interface nested {
     _41_: Variant__42__A_B_C;
     _42_: bigint;
 }
-export interface node {
-    head: bigint;
-    tail: list;
+export type nested_opt = Some<bigint | null> | None;
+export interface nested_records {
+    /**
+     * Doc comment for nested_records field nested
+     */
+    nested?: {
+        nested_field: string;
+    };
 }
-export type A = B;
 export type nested_res = {
     __kind__: "Ok";
     Ok: Variant_Ok_Err;
@@ -127,15 +138,38 @@ export type nested_res = {
         Err: [bigint];
     };
 };
-export type B = Some<A> | None;
-export interface nested_records {
-    /**
-     * Doc comment for nested_records field nested
-     */
-    nested?: {
-        nested_field: string;
-    };
+export interface node {
+    head: bigint;
+    tail: list;
 }
+export type res = {
+    __kind__: "Ok";
+    /**
+     * Doc comment for Ok variant
+     */
+    Ok: [bigint, bigint];
+} | {
+    __kind__: "Err";
+    /**
+     * Doc comment for Err variant
+     */
+    Err: {
+        /**
+         * Doc comment for error field in Err variant,
+         * on multiple lines
+         */
+        error: string;
+    };
+};
+export interface sInterface {
+    f: t;
+    g(arg0: list): Promise<[B, tree, stream]>;
+}
+export type stream = {
+    head: bigint;
+    next: [Principal, string];
+} | null;
+export type t = (server: Principal) => Promise<void>;
 export type tree = {
     __kind__: "branch";
     branch: {
@@ -147,40 +181,6 @@ export type tree = {
     __kind__: "leaf";
     leaf: bigint;
 };
-export type f = (arg0: List, arg1: [Principal, string]) => Promise<[List | null, res]>;
-export interface brokerInterface {
-    find(name: string): Promise<Principal>;
-}
-export type nested_opt = Some<bigint | null> | None;
-/**
- * Doc comment for prim type
- */
-export type my_type = Principal;
-/**
- * Doc comment for List
- */
-export type List = {
-    head: bigint;
-    tail: List;
-} | null;
-export type list = node | null;
-export interface sInterface {
-    f: t;
-    g(arg0: list): Promise<[B, tree, stream]>;
-}
-export type stream = {
-    head: bigint;
-    next: [Principal, string];
-} | null;
-export type b = [bigint, bigint];
-export type a = {
-    __kind__: "a";
-    a: null;
-} | {
-    __kind__: "b";
-    b: b;
-};
-export type t = (server: Principal) => Promise<void>;
 export enum Variant_Ok_Err {
     Ok = "Ok",
     Err = "Err"

--- a/tests/snapshots/wasm-generate/typescript/example/example.ts.snapshot
+++ b/tests/snapshots/wasm-generate/typescript/example/example.ts.snapshot
@@ -60,6 +60,9 @@ export type a = {
     b: b;
 };
 export type b = [bigint, bigint];
+/**
+ * Doc comment for broker service
+ */
 export interface brokerInterface {
     find(name: string): Promise<Principal>;
 }
@@ -92,6 +95,9 @@ export type my_variant = {
         }>;
     } | null;
 };
+/**
+ * Doc comment for nested type
+ */
 export interface nested {
     _0_: bigint;
     _1_: bigint;
@@ -109,6 +115,9 @@ export interface nested {
     _42_: bigint;
 }
 export type nested_opt = Some<bigint | null> | None;
+/**
+ * Doc comment for nested_records
+ */
 export interface nested_records {
     /**
      * Doc comment for nested_records field nested
@@ -142,6 +151,9 @@ export interface node {
     head: bigint;
     tail: list;
 }
+/**
+ * Doc comment for res type
+ */
 export type res = {
     __kind__: "Ok";
     /**
@@ -161,6 +173,9 @@ export type res = {
         error: string;
     };
 };
+/**
+ * Doc comment for service id
+ */
 export interface sInterface {
     f: t;
     g(arg0: list): Promise<[B, tree, stream]>;

--- a/tests/snapshots/wasm-generate/typescript/example/example.ts.snapshot
+++ b/tests/snapshots/wasm-generate/typescript/example/example.ts.snapshot
@@ -43,6 +43,32 @@ function candid_none<T>(): [] {
 function record_opt_to_undefined<T>(arg: T | null): T | undefined {
     return arg == null ? undefined : arg;
 }
+export type A = B;
+export type B = Some<A> | None;
+/**
+ * Doc comment for List
+ */
+export type List = {
+    head: bigint;
+    tail: List;
+} | null;
+export type a = {
+    __kind__: "a";
+    a: null;
+} | {
+    __kind__: "b";
+    b: b;
+};
+export type b = [bigint, bigint];
+export interface brokerInterface {
+    find(name: string): Promise<Principal>;
+}
+export type f = (arg0: List, arg1: [Principal, string]) => Promise<[List | null, res]>;
+export type list = node | null;
+/**
+ * Doc comment for prim type
+ */
+export type my_type = Principal;
 export type my_variant = {
     __kind__: "a";
     /**
@@ -66,25 +92,6 @@ export type my_variant = {
         }>;
     } | null;
 };
-export type res = {
-    __kind__: "Ok";
-    /**
-     * Doc comment for Ok variant
-     */
-    Ok: [bigint, bigint];
-} | {
-    __kind__: "Err";
-    /**
-     * Doc comment for Err variant
-     */
-    Err: {
-        /**
-         * Doc comment for error field in Err variant,
-         * on multiple lines
-         */
-        error: string;
-    };
-};
 export interface nested {
     _0_: bigint;
     _1_: bigint;
@@ -101,11 +108,15 @@ export interface nested {
     _41_: Variant__42__A_B_C;
     _42_: bigint;
 }
-export interface node {
-    head: bigint;
-    tail: list;
+export type nested_opt = Some<bigint | null> | None;
+export interface nested_records {
+    /**
+     * Doc comment for nested_records field nested
+     */
+    nested?: {
+        nested_field: string;
+    };
 }
-export type A = B;
 export type nested_res = {
     __kind__: "Ok";
     Ok: Variant_Ok_Err;
@@ -127,15 +138,38 @@ export type nested_res = {
         Err: [bigint];
     };
 };
-export type B = Some<A> | None;
-export interface nested_records {
-    /**
-     * Doc comment for nested_records field nested
-     */
-    nested?: {
-        nested_field: string;
-    };
+export interface node {
+    head: bigint;
+    tail: list;
 }
+export type res = {
+    __kind__: "Ok";
+    /**
+     * Doc comment for Ok variant
+     */
+    Ok: [bigint, bigint];
+} | {
+    __kind__: "Err";
+    /**
+     * Doc comment for Err variant
+     */
+    Err: {
+        /**
+         * Doc comment for error field in Err variant,
+         * on multiple lines
+         */
+        error: string;
+    };
+};
+export interface sInterface {
+    f: t;
+    g(arg0: list): Promise<[B, tree, stream]>;
+}
+export type stream = {
+    head: bigint;
+    next: [Principal, string];
+} | null;
+export type t = (server: Principal) => Promise<void>;
 export type tree = {
     __kind__: "branch";
     branch: {
@@ -147,40 +181,6 @@ export type tree = {
     __kind__: "leaf";
     leaf: bigint;
 };
-export type f = (arg0: List, arg1: [Principal, string]) => Promise<[List | null, res]>;
-export interface brokerInterface {
-    find(name: string): Promise<Principal>;
-}
-export type nested_opt = Some<bigint | null> | None;
-/**
- * Doc comment for prim type
- */
-export type my_type = Principal;
-/**
- * Doc comment for List
- */
-export type List = {
-    head: bigint;
-    tail: List;
-} | null;
-export type list = node | null;
-export interface sInterface {
-    f: t;
-    g(arg0: list): Promise<[B, tree, stream]>;
-}
-export type stream = {
-    head: bigint;
-    next: [Principal, string];
-} | null;
-export type b = [bigint, bigint];
-export type a = {
-    __kind__: "a";
-    a: null;
-} | {
-    __kind__: "b";
-    b: b;
-};
-export type t = (server: Principal) => Promise<void>;
 export enum Variant_Ok_Err {
     Ok = "Ok",
     Err = "Err"


### PR DESCRIPTION
## Summary

Decouples the bindgen crate from the floating `candid` / `candid_parser` **`next`** branch and pins it to the published **`candid` 0.10.30** / **`candid_parser` 0.4.0** releases.

## Why

candid `next` carried breaking changes — named args baked into `candid::types::Function`, a `HashMap`/`TypeKey`-based `TypeEnv`, and a serde rewrite — that are not headed to a stable release. Depending on it tied the build to a moving target. This PR keeps candid on its stable **0.10 type model** and recovers the only feature the bindgen actually needs — **named function arguments** — from the parser AST instead.

## Changes

- **Deps**: `candid` / `candid_parser` → published `0.10.30` / `0.4.0` (was the `next` branch).
- **`parser.rs`**: builds nameless `candid::types::Function` / `Class` and keys `TypeEnv` by `String` (no `ArgType` / `TypeKey`).
- **TS binding generators**: recover argument names from the parser AST (`syntax::IDLArgType.name`), threaded alongside the checked types. Service-method and func-type-alias signatures keep meaningful parameter names; nested/anonymous funcs fall back to positional `arg{i}` (valid TS).
- **Native TS type definitions** are emitted in sorted order via `to_sorted_iter`, matching the original-format generators, so output is deterministic regardless of candid's internal `TypeEnv` representation.

## Test plan

- [x] `cargo build` (host) and `cargo build --target wasm32-unknown-unknown` — clean
- [x] `cargo fmt --check` / `cargo clippy` — clean
- [x] JS test suite (`vitest`) — 52/52 passing, type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)